### PR TITLE
Add scalar multiply function

### DIFF
--- a/encryption/ecies/ecies.go
+++ b/encryption/ecies/ecies.go
@@ -21,11 +21,12 @@ func GenerateKey(curve elliptic.Curve) (*PrivateKey, error) {
 	}
 
 	return &PrivateKey{
-		d: new(big.Int).SetBytes(priv),
+		k: new(big.Int).SetBytes(priv),
 		Pub: &PublicKey{
-			Curve: curve,
-			X:     x,
-			Y:     y,
+			curve: curve,
+			Point: &Point{
+				X: x,
+				Y: y},
 		},
 	}, nil
 }
@@ -91,7 +92,7 @@ func Encrypt(data []byte, pub *PublicKey, ecdh ECDH, kdf KDF) ([]byte, error) {
 	}
 
 	// generate an ephemeral key pair
-	priv, err := GenerateKey(pub.Curve)
+	priv, err := GenerateKey(pub.curve)
 	if err != nil {
 		return nil, err
 	}
@@ -126,13 +127,13 @@ func Decrypt(data []byte, priv *PrivateKey, ecdh ECDH, kdf KDF) ([]byte, error) 
 	}
 
 	// check if the ciphertext is long enough
-	pubKeySize := publicKeySize(keySize(priv.Pub.Curve))
+	pubKeySize := publicKeySize(keySize(priv.Pub.curve))
 	if len(data) <= pubKeySize {
 		return nil, errors.New(encryption.MsgCiphertextTooShort)
 	}
 
 	// parse the public key
-	pub, err := PublicKeyFromBytes(data[:pubKeySize], priv.Pub.Curve)
+	pub, err := PublicKeyFromBytes(data[:pubKeySize], priv.Pub.curve)
 	if err != nil {
 		return nil, err
 	}

--- a/encryption/ecies/ecies.go
+++ b/encryption/ecies/ecies.go
@@ -24,8 +24,8 @@ func GenerateKey(curve elliptic.Curve) (*PrivateKey, error) {
 		d: new(big.Int).SetBytes(priv),
 		Pub: &PublicKey{
 			Curve: curve,
-			x:     x,
-			y:     y,
+			X:     x,
+			Y:     y,
 		},
 	}, nil
 }

--- a/encryption/ecies/ecies.go
+++ b/encryption/ecies/ecies.go
@@ -23,7 +23,7 @@ func GenerateKey(curve elliptic.Curve) (*PrivateKey, error) {
 	return &PrivateKey{
 		d: new(big.Int).SetBytes(priv),
 		Pub: &PublicKey{
-			curve: curve,
+			Curve: curve,
 			x:     x,
 			y:     y,
 		},
@@ -91,7 +91,7 @@ func Encrypt(data []byte, pub *PublicKey, ecdh ECDH, kdf KDF) ([]byte, error) {
 	}
 
 	// generate an ephemeral key pair
-	priv, err := GenerateKey(pub.curve)
+	priv, err := GenerateKey(pub.Curve)
 	if err != nil {
 		return nil, err
 	}
@@ -126,13 +126,13 @@ func Decrypt(data []byte, priv *PrivateKey, ecdh ECDH, kdf KDF) ([]byte, error) 
 	}
 
 	// check if the ciphertext is long enough
-	pubKeySize := publicKeySize(keySize(priv.Pub.curve))
+	pubKeySize := publicKeySize(keySize(priv.Pub.Curve))
 	if len(data) <= pubKeySize {
 		return nil, errors.New(encryption.MsgCiphertextTooShort)
 	}
 
 	// parse the public key
-	pub, err := PublicKeyFromBytes(data[:pubKeySize], priv.Pub.curve)
+	pub, err := PublicKeyFromBytes(data[:pubKeySize], priv.Pub.Curve)
 	if err != nil {
 		return nil, err
 	}

--- a/encryption/ecies/ecies_test.go
+++ b/encryption/ecies/ecies_test.go
@@ -114,3 +114,18 @@ func Test_DecryptHexString_InvalidPublicKeyBytes(t *testing.T) {
 	assert.Contains(err.Error(), "message authentication failed")
 	assert.Empty(plaintext)
 }
+
+func Test_PublicKey_ScalarMult(t *testing.T) {
+	assert := assert.New(t)
+
+	newPriv, err := ecies.GenerateKey(curve)
+	assert.NoError(err)
+
+	// if we implement correctly then
+	// (publicKeyA * privateKeyB) = (publicKeyB * privateKeyA)
+	point1 := newPriv.Pub.ScalarMult(priv)
+	point2 := priv.Pub.ScalarMult(newPriv)
+
+	assert.Equal(point1.X, point2.X)
+	assert.Equal(point1.Y, point2.Y)
+}

--- a/encryption/ecies/keys.go
+++ b/encryption/ecies/keys.go
@@ -19,23 +19,23 @@ type KDF func(masterSecret []byte) (key []byte, err error)
 type ECDH func(priv *PrivateKey, pub *PublicKey) (masterSecret []byte)
 
 func defaultEncryptECDH(sender *PrivateKey, receiver *PublicKey) []byte {
-	x, y := receiver.Curve.ScalarMult(receiver.X, receiver.Y, sender.d.Bytes())
+	p := receiver.ScalarMult(sender)
 
 	var key bytes.Buffer
-	key.Write(x.Bytes())
+	key.Write(p.X.Bytes())
 	key.Write(receiver.Bytes())
-	key.Write(y.Bytes())
+	key.Write(p.Y.Bytes())
 
 	return key.Bytes()
 }
 
 func defaultDecryptECDH(receiver *PrivateKey, sender *PublicKey) []byte {
-	x, y := sender.Curve.ScalarMult(sender.X, sender.Y, receiver.d.Bytes())
+	p := sender.ScalarMult(receiver)
 
 	var key bytes.Buffer
-	key.Write(x.Bytes())
+	key.Write(p.X.Bytes())
 	key.Write(receiver.Pub.Bytes())
-	key.Write(y.Bytes())
+	key.Write(p.Y.Bytes())
 
 	return key.Bytes()
 }

--- a/encryption/ecies/keys.go
+++ b/encryption/ecies/keys.go
@@ -19,7 +19,7 @@ type KDF func(masterSecret []byte) (key []byte, err error)
 type ECDH func(priv *PrivateKey, pub *PublicKey) (masterSecret []byte)
 
 func defaultEncryptECDH(sender *PrivateKey, receiver *PublicKey) []byte {
-	x, y := receiver.Curve.ScalarMult(receiver.x, receiver.y, sender.d.Bytes())
+	x, y := receiver.Curve.ScalarMult(receiver.X, receiver.Y, sender.d.Bytes())
 
 	var key bytes.Buffer
 	key.Write(x.Bytes())
@@ -30,7 +30,7 @@ func defaultEncryptECDH(sender *PrivateKey, receiver *PublicKey) []byte {
 }
 
 func defaultDecryptECDH(receiver *PrivateKey, sender *PublicKey) []byte {
-	x, y := sender.Curve.ScalarMult(sender.x, sender.y, receiver.d.Bytes())
+	x, y := sender.Curve.ScalarMult(sender.X, sender.Y, receiver.d.Bytes())
 
 	var key bytes.Buffer
 	key.Write(x.Bytes())

--- a/encryption/ecies/keys.go
+++ b/encryption/ecies/keys.go
@@ -19,7 +19,7 @@ type KDF func(masterSecret []byte) (key []byte, err error)
 type ECDH func(priv *PrivateKey, pub *PublicKey) (masterSecret []byte)
 
 func defaultEncryptECDH(sender *PrivateKey, receiver *PublicKey) []byte {
-	x, y := receiver.curve.ScalarMult(receiver.x, receiver.y, sender.d.Bytes())
+	x, y := receiver.Curve.ScalarMult(receiver.x, receiver.y, sender.d.Bytes())
 
 	var key bytes.Buffer
 	key.Write(x.Bytes())
@@ -30,7 +30,7 @@ func defaultEncryptECDH(sender *PrivateKey, receiver *PublicKey) []byte {
 }
 
 func defaultDecryptECDH(receiver *PrivateKey, sender *PublicKey) []byte {
-	x, y := sender.curve.ScalarMult(sender.x, sender.y, receiver.d.Bytes())
+	x, y := sender.Curve.ScalarMult(sender.x, sender.y, receiver.d.Bytes())
 
 	var key bytes.Buffer
 	key.Write(x.Bytes())

--- a/encryption/ecies/privatekey.go
+++ b/encryption/ecies/privatekey.go
@@ -22,7 +22,7 @@ func PrivateKeyFromBytes(b []byte, curve elliptic.Curve) *PrivateKey {
 	return &PrivateKey{
 		d: new(big.Int).SetBytes(b),
 		Pub: &PublicKey{
-			curve: curve,
+			Curve: curve,
 			x:     x,
 			y:     y,
 		},

--- a/encryption/ecies/privatekey.go
+++ b/encryption/ecies/privatekey.go
@@ -23,8 +23,8 @@ func PrivateKeyFromBytes(b []byte, curve elliptic.Curve) *PrivateKey {
 		d: new(big.Int).SetBytes(b),
 		Pub: &PublicKey{
 			Curve: curve,
-			x:     x,
-			y:     y,
+			X:     x,
+			Y:     y,
 		},
 	}
 }

--- a/encryption/ecies/privatekey.go
+++ b/encryption/ecies/privatekey.go
@@ -12,7 +12,7 @@ import (
 // PrivateKey ...
 type PrivateKey struct {
 	Pub *PublicKey
-	d   *big.Int
+	k   *big.Int
 }
 
 // PrivateKeyFromBytes parses a private key from its raw bytes
@@ -20,11 +20,13 @@ func PrivateKeyFromBytes(b []byte, curve elliptic.Curve) *PrivateKey {
 	x, y := curve.ScalarBaseMult(b)
 
 	return &PrivateKey{
-		d: new(big.Int).SetBytes(b),
+		k: new(big.Int).SetBytes(b),
 		Pub: &PublicKey{
-			Curve: curve,
-			X:     x,
-			Y:     y,
+			curve: curve,
+			Point: &Point{
+				X: x,
+				Y: y,
+			},
 		},
 	}
 }
@@ -51,7 +53,7 @@ func PrivateKeyFromHex(hexKey string, curve elliptic.Curve) (*PrivateKey, error)
 
 // Bytes returns private key raw bytes
 func (priv *PrivateKey) Bytes() []byte {
-	return priv.d.Bytes()
+	return priv.k.Bytes()
 }
 
 // Base64 returns private key bytes in base64 form

--- a/encryption/ecies/publickey.go
+++ b/encryption/ecies/publickey.go
@@ -13,7 +13,7 @@ import (
 
 // PublicKey ...
 type PublicKey struct {
-	curve elliptic.Curve
+	Curve elliptic.Curve
 	x, y  *big.Int
 }
 
@@ -25,7 +25,7 @@ func PublicKeyFromBytes(b []byte, curve elliptic.Curve) (*PublicKey, error) {
 	}
 
 	return &PublicKey{
-		curve: curve,
+		Curve: curve,
 		x:     new(big.Int).SetBytes(b[1 : size+1]),
 		y:     new(big.Int).SetBytes(b[size+1:]),
 	}, nil
@@ -54,7 +54,7 @@ func PublicKeyFromHex(hexKey string, curve elliptic.Curve) (*PublicKey, error) {
 // Bytes returns the public key to raw bytes in uncompressed format (Ox04|x|y)
 // https://secg.org/sec1-v2.pdf#subsubsection.2.3.3
 func (pub *PublicKey) Bytes() []byte {
-	size := keySize(pub.curve)
+	size := keySize(pub.Curve)
 
 	x := zeroPad(pub.x.Bytes(), size)
 	y := zeroPad(pub.y.Bytes(), size)

--- a/encryption/ecies/publickey.go
+++ b/encryption/ecies/publickey.go
@@ -14,7 +14,7 @@ import (
 // PublicKey ...
 type PublicKey struct {
 	Curve elliptic.Curve
-	x, y  *big.Int
+	X, Y  *big.Int
 }
 
 // PublicKeyFromBytes parses a public key from its uncompressed raw bytes
@@ -26,8 +26,8 @@ func PublicKeyFromBytes(b []byte, curve elliptic.Curve) (*PublicKey, error) {
 
 	return &PublicKey{
 		Curve: curve,
-		x:     new(big.Int).SetBytes(b[1 : size+1]),
-		y:     new(big.Int).SetBytes(b[size+1:]),
+		X:     new(big.Int).SetBytes(b[1 : size+1]),
+		Y:     new(big.Int).SetBytes(b[size+1:]),
 	}, nil
 }
 
@@ -56,8 +56,8 @@ func PublicKeyFromHex(hexKey string, curve elliptic.Curve) (*PublicKey, error) {
 func (pub *PublicKey) Bytes() []byte {
 	size := keySize(pub.Curve)
 
-	x := zeroPad(pub.x.Bytes(), size)
-	y := zeroPad(pub.y.Bytes(), size)
+	x := zeroPad(pub.X.Bytes(), size)
+	y := zeroPad(pub.Y.Bytes(), size)
 
 	return bytes.Join([][]byte{{0x04}, x, y}, nil)
 }


### PR DESCRIPTION
- `PrivateKey`:

  - Rename `d` to `k` follow [this](https://cryptobook.nakov.com/asymmetric-key-ciphers/elliptic-curve-cryptography-ecc#private-key-public-key-and-the-generator-point-in-ecc)
    ```
    Еlliptic curve (EC) over finite field 𝔽p
    G == generator point (fixed constant, a base point on the EC)
    k == private key (integer)
    P == public key (point)
    ```

- `PublicKey`:

  - Add `ScalarMulti` function. So that clients can use it to implement their custom ECDH.