### PR TITLE
Add `EncryptToHex` and `EncryptToBase64`

### DIFF
--- a/encryption/aes/aes.go
+++ b/encryption/aes/aes.go
@@ -16,19 +16,24 @@ import (
 // KeyLength is the min length of the secret key
 const KeyLength = 32
 
-// error
 var (
+	// ErrShortKey key is too short
 	ErrShortKey = fmt.Errorf("key is too short, %d bytes is required", KeyLength)
 )
 
-// EncryptStringToHex encrypts plaintext to ciphertext (hex form) using 256-bit AES-GCM, key must have length 32 or more
-func EncryptStringToHex(plaintext, key string) (string, error) {
-	bytes, err := Encrypt([]byte(plaintext), []byte(key))
+// EncryptToHex encrypts data to ciphertext (hex form) using 256-bit AES-GCM, key must have length 32 or more
+func EncryptToHex(data []byte, key string) (string, error) {
+	bytes, err := Encrypt(data, []byte(key))
 	if err != nil {
 		return "", err
 	}
 
 	return hex.EncodeToString(bytes), nil
+}
+
+// EncryptStringToHex encrypts plaintext to ciphertext (hex form) using 256-bit AES-GCM, key must have length 32 or more
+func EncryptStringToHex(plaintext, key string) (string, error) {
+	return EncryptToHex([]byte(plaintext), key)
 }
 
 // DecryptHexString decrypts a hex form ciphertext to the plaintext using 256-bit AES-GCM, key must have length 32 or more
@@ -46,14 +51,19 @@ func DecryptHexString(ciphertext, key string) (string, error) {
 	return string(bytes), nil
 }
 
-// EncryptStringToBase64 encrypts plaintext to ciphertext (base64 form) using 256-bit AES-GCM, key must have length 32 or more
-func EncryptStringToBase64(plaintext, key string) (string, error) {
-	bytes, err := Encrypt([]byte(plaintext), []byte(key))
+// EncryptToBase64 encrypts data to ciphertext (base64 form) using 256-bit AES-GCM, key must have length 32 or more
+func EncryptToBase64(data []byte, key string) (string, error) {
+	bytes, err := Encrypt(data, []byte(key))
 	if err != nil {
 		return "", err
 	}
 
 	return base64.StdEncoding.EncodeToString(bytes), nil
+}
+
+// EncryptStringToBase64 encrypts plaintext to ciphertext (base64 form) using 256-bit AES-GCM, key must have length 32 or more
+func EncryptStringToBase64(plaintext, key string) (string, error) {
+	return EncryptToBase64([]byte(plaintext), key)
 }
 
 // DecryptBase64String decrypts a base64 form ciphertext to the plaintext using 256-bit AES-GCM, key must have length 32 or more

--- a/encryption/aes/aes.go
+++ b/encryption/aes/aes.go
@@ -36,14 +36,19 @@ func EncryptStringToHex(plaintext, key string) (string, error) {
 	return EncryptToHex([]byte(plaintext), key)
 }
 
-// DecryptHexString decrypts a hex form ciphertext to the plaintext using 256-bit AES-GCM, key must have length 32 or more
-func DecryptHexString(ciphertext, key string) (string, error) {
+// DecryptHex decrypts a hex form ciphertext to raw data([]byte) using 256-bit AES-GCM, key must have length 32 or more
+func DecryptHex(ciphertext, key string) ([]byte, error) {
 	data, err := hex.DecodeString(ciphertext)
 	if err != nil {
-		return "", errors.New(encryption.MsgInvalidHexString, err)
+		return nil, errors.New(encryption.MsgInvalidHexString, err)
 	}
 
-	bytes, err := Decrypt(data, []byte(key))
+	return Decrypt(data, []byte(key))
+}
+
+// DecryptHexString decrypts a hex form ciphertext to the plaintext using 256-bit AES-GCM, key must have length 32 or more
+func DecryptHexString(ciphertext, key string) (string, error) {
+	bytes, err := DecryptHex(ciphertext, key)
 	if err != nil {
 		return "", err
 	}
@@ -66,14 +71,19 @@ func EncryptStringToBase64(plaintext, key string) (string, error) {
 	return EncryptToBase64([]byte(plaintext), key)
 }
 
-// DecryptBase64String decrypts a base64 form ciphertext to the plaintext using 256-bit AES-GCM, key must have length 32 or more
-func DecryptBase64String(ciphertext, key string) (string, error) {
+// DecryptBase64 decrypts a base64 form ciphertext to raw data([]byte) using 256-bit AES-GCM, key must have length 32 or more
+func DecryptBase64(ciphertext, key string) ([]byte, error) {
 	data, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {
-		return "", errors.New(encryption.MsgInvalidBase64String, err)
+		return nil, errors.New(encryption.MsgInvalidBase64String, err)
 	}
 
-	bytes, err := Decrypt(data, []byte(key))
+	return Decrypt(data, []byte(key))
+}
+
+// DecryptBase64String decrypts a base64 form ciphertext to the plaintext using 256-bit AES-GCM, key must have length 32 or more
+func DecryptBase64String(ciphertext, key string) (string, error) {
+	bytes, err := DecryptBase64(ciphertext, key)
 	if err != nil {
 		return "", err
 	}

--- a/encryption/aes/aes_test.go
+++ b/encryption/aes/aes_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	key       = "1234567890qwertyuiop0123456789as"
-	plaintext = "Wego is awesome!"
+	key        = "1234567890qwertyuiop0123456789as"
+	plaintext  = "Wego is awesome!"
+	plainBytes = []byte(plaintext)
 )
 
 func Test_EncryptBase64_DecryptBase64_Ok(t *testing.T) {
@@ -29,6 +30,18 @@ func Test_EncryptBase64_DecryptBase64_Ok(t *testing.T) {
 	decrypted, err := aes.DecryptBase64String(ciphertext, key)
 	assert.NoError(err)
 	assert.Equal(plaintext, decrypted)
+
+	ciphertext, err = aes.EncryptToBase64(plainBytes, key)
+	assert.NoError(err)
+	assert.NotEmpty(ciphertext)
+
+	bytes, err = base64.StdEncoding.DecodeString(ciphertext)
+	assert.NoError(err)
+	assert.NotZero(len(bytes))
+
+	decrypted, err = aes.DecryptBase64String(ciphertext, key)
+	assert.NoError(err)
+	assert.Equal(plaintext, decrypted)
 }
 
 func Test_EncryptHexString_DecryptHexString_Ok(t *testing.T) {
@@ -43,6 +56,18 @@ func Test_EncryptHexString_DecryptHexString_Ok(t *testing.T) {
 	assert.NotZero(len(bytes))
 
 	decrypted, err := aes.DecryptHexString(ciphertext, key)
+	assert.NoError(err)
+	assert.Equal(plaintext, decrypted)
+
+	ciphertext, err = aes.EncryptToHex(plainBytes, key)
+	assert.NoError(err)
+	assert.NotEmpty(ciphertext)
+
+	bytes, err = hex.DecodeString(ciphertext)
+	assert.NoError(err)
+	assert.NotZero(len(bytes))
+
+	decrypted, err = aes.DecryptHexString(ciphertext, key)
 	assert.NoError(err)
 	assert.Equal(plaintext, decrypted)
 }

--- a/encryption/aes/aes_test.go
+++ b/encryption/aes/aes_test.go
@@ -39,9 +39,9 @@ func Test_EncryptBase64_DecryptBase64_Ok(t *testing.T) {
 	assert.NoError(err)
 	assert.NotZero(len(bytes))
 
-	decrypted, err = aes.DecryptBase64String(ciphertext, key)
+	decryptedData, err := aes.DecryptBase64(ciphertext, key)
 	assert.NoError(err)
-	assert.Equal(plaintext, decrypted)
+	assert.Equal(plainBytes, decryptedData)
 }
 
 func Test_EncryptHexString_DecryptHexString_Ok(t *testing.T) {
@@ -67,9 +67,9 @@ func Test_EncryptHexString_DecryptHexString_Ok(t *testing.T) {
 	assert.NoError(err)
 	assert.NotZero(len(bytes))
 
-	decrypted, err = aes.DecryptHexString(ciphertext, key)
+	decryptedData, err := aes.DecryptHex(ciphertext, key)
 	assert.NoError(err)
-	assert.Equal(plaintext, decrypted)
+	assert.Equal(plainBytes, decryptedData)
 }
 
 func Test_Encrypt_KeyIsTooShort(t *testing.T) {

--- a/encryption/ecies/ecies.go
+++ b/encryption/ecies/ecies.go
@@ -31,9 +31,9 @@ func GenerateKey(curve elliptic.Curve) (*PrivateKey, error) {
 	}, nil
 }
 
-// EncryptStringToBase64 encrypts plaintext to ciphertext in base64 form using receiver public key
-func EncryptStringToBase64(plaintext string, pub *PublicKey, ecdh ECDH, kdf KDF) (string, error) {
-	bytes, err := Encrypt([]byte(plaintext), pub, ecdh, kdf)
+// EncryptToBase64 encrypts data to ciphertext in base64 form using receiver public key
+func EncryptToBase64(data []byte, pub *PublicKey, ecdh ECDH, kdf KDF) (string, error) {
+	bytes, err := Encrypt(data, pub, ecdh, kdf)
 	if err != nil {
 		return "", err
 	}
@@ -41,9 +41,14 @@ func EncryptStringToBase64(plaintext string, pub *PublicKey, ecdh ECDH, kdf KDF)
 	return base64.StdEncoding.EncodeToString(bytes), nil
 }
 
-// EncryptStringToHex encrypts plaintext to ciphertext in hex form using receiver public key
-func EncryptStringToHex(plaintext string, pub *PublicKey, ecdh ECDH, kdf KDF) (string, error) {
-	bytes, err := Encrypt([]byte(plaintext), pub, ecdh, kdf)
+// EncryptStringToBase64 encrypts plaintext to ciphertext in base64 form using receiver public key
+func EncryptStringToBase64(plaintext string, pub *PublicKey, ecdh ECDH, kdf KDF) (string, error) {
+	return EncryptToBase64([]byte(plaintext), pub, ecdh, kdf)
+}
+
+// EncryptToHex encrypts data to ciphertext in hex form using receiver public key
+func EncryptToHex(data []byte, pub *PublicKey, ecdh ECDH, kdf KDF) (string, error) {
+	bytes, err := Encrypt(data, pub, ecdh, kdf)
 	if err != nil {
 		return "", err
 	}
@@ -51,14 +56,24 @@ func EncryptStringToHex(plaintext string, pub *PublicKey, ecdh ECDH, kdf KDF) (s
 	return hex.EncodeToString(bytes), nil
 }
 
-// DecryptBase64String decrypts ciphertext in base64 form to plaintext by receiver private key
-func DecryptBase64String(ciphertext string, priv *PrivateKey, ecdh ECDH, kdf KDF) (string, error) {
+// EncryptStringToHex encrypts plaintext to ciphertext in hex form using receiver public key
+func EncryptStringToHex(plaintext string, pub *PublicKey, ecdh ECDH, kdf KDF) (string, error) {
+	return EncryptToHex([]byte(plaintext), pub, ecdh, kdf)
+}
+
+// DecryptBase64 decrypts ciphertext in base64 form to raw data([]byte) by receiver private key
+func DecryptBase64(ciphertext string, priv *PrivateKey, ecdh ECDH, kdf KDF) ([]byte, error) {
 	data, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {
-		return "", errors.New(encryption.MsgInvalidBase64String, err)
+		return nil, errors.New(encryption.MsgInvalidBase64String, err)
 	}
 
-	bytes, err := Decrypt(data, priv, ecdh, kdf)
+	return Decrypt(data, priv, ecdh, kdf)
+}
+
+// DecryptBase64String decrypts ciphertext in base64 form to plaintext by receiver private key
+func DecryptBase64String(ciphertext string, priv *PrivateKey, ecdh ECDH, kdf KDF) (string, error) {
+	bytes, err := DecryptBase64(ciphertext, priv, ecdh, kdf)
 	if err != nil {
 		return "", err
 	}
@@ -66,14 +81,19 @@ func DecryptBase64String(ciphertext string, priv *PrivateKey, ecdh ECDH, kdf KDF
 	return string(bytes), nil
 }
 
-// DecryptHexString decrypts ciphertext in hex form to plaintext by receiver private key
-func DecryptHexString(ciphertext string, priv *PrivateKey, ecdh ECDH, kdf KDF) (string, error) {
+// DecryptHex decrypts ciphertext in hex form to raw data([]byte) by receiver private key
+func DecryptHex(ciphertext string, priv *PrivateKey, ecdh ECDH, kdf KDF) ([]byte, error) {
 	data, err := hex.DecodeString(ciphertext)
 	if err != nil {
-		return "", errors.New(encryption.MsgInvalidHexString, err)
+		return nil, errors.New(encryption.MsgInvalidHexString, err)
 	}
 
-	bytes, err := Decrypt(data, priv, ecdh, kdf)
+	return Decrypt(data, priv, ecdh, kdf)
+}
+
+// DecryptHexString decrypts ciphertext in hex form to plaintext by receiver private key
+func DecryptHexString(ciphertext string, priv *PrivateKey, ecdh ECDH, kdf KDF) (string, error) {
+	bytes, err := DecryptHex(ciphertext, priv, ecdh, kdf)
 	if err != nil {
 		return "", err
 	}

--- a/encryption/ecies/ecies_test.go
+++ b/encryption/ecies/ecies_test.go
@@ -12,15 +12,16 @@ import (
 )
 
 var (
-	curve   = elliptic.P521()
-	priv, _ = ecies.GenerateKey(curve)
-	msg     = "Wego is awesome!"
+	curve      = elliptic.P521()
+	priv, _    = ecies.GenerateKey(curve)
+	plainText  = "Wego is awesome!"
+	plainBytes = []byte(plainText)
 )
 
 func Test_EncryptBase64String_DecryptBase64String_Ok(t *testing.T) {
 	assert := assert.New(t)
 
-	ciphertext, err := ecies.EncryptStringToBase64(msg, priv.Pub, nil, nil)
+	ciphertext, err := ecies.EncryptStringToBase64(plainText, priv.Pub, nil, nil)
 	assert.NoError(err)
 	assert.NotEmpty(ciphertext)
 
@@ -30,13 +31,26 @@ func Test_EncryptBase64String_DecryptBase64String_Ok(t *testing.T) {
 
 	decoded, err := ecies.DecryptBase64String(ciphertext, priv, nil, nil)
 	assert.NoError(err)
-	assert.Equal(msg, decoded)
+	assert.Equal(plainText, decoded)
+
+	ciphertext, err = ecies.EncryptToBase64(plainBytes, priv.Pub, nil, nil)
+	assert.NoError(err)
+	assert.NotEmpty(ciphertext)
+
+	bytes, err = base64.StdEncoding.DecodeString(ciphertext)
+	assert.NoError(err)
+	assert.NotEmpty(bytes)
+
+	decryptedData, err := ecies.DecryptBase64(ciphertext, priv, nil, nil)
+	assert.NoError(err)
+	assert.Equal(plainBytes, decryptedData)
+
 }
 
 func Test_EncryptHexString_DecryptHexString_Ok(t *testing.T) {
 	assert := assert.New(t)
 
-	ciphertext, err := ecies.EncryptStringToHex(msg, priv.Pub, nil, nil)
+	ciphertext, err := ecies.EncryptStringToHex(plainText, priv.Pub, nil, nil)
 	assert.NoError(err)
 	assert.NotEmpty(ciphertext)
 
@@ -46,7 +60,19 @@ func Test_EncryptHexString_DecryptHexString_Ok(t *testing.T) {
 
 	decoded, err := ecies.DecryptHexString(ciphertext, priv, nil, nil)
 	assert.NoError(err)
-	assert.Equal(msg, decoded)
+	assert.Equal(plainText, decoded)
+
+	ciphertext, err = ecies.EncryptToHex(plainBytes, priv.Pub, nil, nil)
+	assert.NoError(err)
+	assert.NotEmpty(ciphertext)
+
+	bytes, err = hex.DecodeString(ciphertext)
+	assert.NoError(err)
+	assert.NotEmpty(bytes)
+
+	decryptedData, err := ecies.DecryptHex(ciphertext, priv, nil, nil)
+	assert.NoError(err)
+	assert.Equal(plainBytes, decryptedData)
 }
 
 func Test_DecryptBase64String_Ciphertext_TooShort(t *testing.T) {


### PR DESCRIPTION
Purpose:
Add `EncryptToHex` and `EncryptToBase64` to accept `[]byte` as parameter and corresponding decrypt func