### PR TITLE
Update currency factors map & rename function to make it clearer

### DIFF
--- a/currency/currency.go
+++ b/currency/currency.go
@@ -45,26 +45,27 @@ var iso4217Currencies = map[string]bool{
 	"YER": true, "ZAR": true, "ZMW": true, "ZWL": true,
 }
 
-//  https://docs.checkout.com/docs/calculating-the-value
+//  https://www.checkout.com/docs/resources/calculating-the-value
 const defaultCurrencyFactor = 100
 
 var currencyFactors = map[string]uint{
 	// Currencies have full value
 	"BIF": 1, // Burundian Franc
+	"CLF": 1, // Chilean Unidad de Fomentos
 	"DJF": 1, // Djiboutian Franc
 	"GNF": 1, // Guinean Franc
 	"ISK": 1, // Icelandic Krona
-	"KMF": 1, // Comoran Franc
-	"XAF": 1, // Central African Franc
-	"CLF": 1, // Chilean Unidad de Fomentos
-	"XPF": 1, // Comptoirs Français du Pacifique
 	"JPY": 1, // Japanese Yen
+	"KMF": 1, // Comoran Franc
+	"KRW": 1, // South Korean Won
 	"PYG": 1, // Paraguayan Guarani
 	"RWF": 1, // Rwandan Franc
-	"KRW": 1, // South Korean Won
+	"UGX": 1, // Ugandan Shilling
 	"VUV": 1, // Vanuatu Vatu
 	"VND": 1, // Vietnamese Dong
+	"XAF": 1, // Central African Franc
 	"XOF": 1, // West African CFA franc
+	"XPF": 1, // Comptoirs Français du Pacifique
 
 	// Currencies have value divided by 1000
 	"BHD": 1000, // Bahraini Dinar
@@ -76,8 +77,9 @@ var currencyFactors = map[string]uint{
 	"TND": 1000, // Tunisian Dinar
 }
 
-// AmountToAmountInCents converts amount in a currency to amount in smallest unit of that currency
-func AmountToAmountInCents(currencyCode string, amount float64) (amountInCents uint64, err error) {
+// ToMinorUnit converts amount in a currency to amount in smallest unit (minor unit)
+// https://en.wikipedia.org/wiki/ISO_4217#Minor_units_of_currency
+func ToMinorUnit(currencyCode string, amount float64) (minorUnitAmount uint64, err error) {
 	if !IsISO4217(currencyCode) {
 		err = fmt.Errorf("%s is not a valid ISO 4217 currency code", currencyCode)
 		return
@@ -85,28 +87,28 @@ func AmountToAmountInCents(currencyCode string, amount float64) (amountInCents u
 	switch {
 	case amount > 0:
 		factor := getCurrencyFactor(currencyCode)
-		amountInCents = uint64(math.Round(amount * float64(factor)))
+		minorUnitAmount = uint64(math.Round(amount * float64(factor)))
 	case amount == 0:
-		amountInCents = 0
+		minorUnitAmount = 0
 	default:
 		err = fmt.Errorf("invalid amount: %f", amount)
 	}
 	return
 }
 
-// AmountInCentsToAmount converts amount in the smallest unit of a currency to amount in that currency
-func AmountInCentsToAmount(currencyCode string, amountInCents uint64) (amount float64, err error) {
+// FromMinorUnit converts amount in the smallest unit (minor unit) of a currency to amount in that currency
+func FromMinorUnit(currencyCode string, minorUnitAmount uint64) (amount float64, err error) {
 	if !IsISO4217(currencyCode) {
 		err = fmt.Errorf("%s is not a valid ISO 4217 currency code", currencyCode)
 		return
 	}
 	switch {
-	case amountInCents > 0:
+	case minorUnitAmount > 0:
 		factor := getCurrencyFactor(currencyCode)
-		amount = float64(amountInCents) / float64(factor)
+		amount = float64(minorUnitAmount) / float64(factor)
 		amount = math.Round(amount*float64(factor)) / float64(factor)
 		return
-	case amountInCents == 0:
+	case minorUnitAmount == 0:
 		amount = 0
 	default:
 		err = fmt.Errorf("invalid amount: %f", amount)

--- a/currency/currency_test.go
+++ b/currency/currency_test.go
@@ -18,140 +18,140 @@ func Test_IsISO4217(t *testing.T) {
 	assert.False(currency.IsISO4217(""))
 }
 
-func Test_AmountToAmountInCents_Ok(t *testing.T) {
+func Test_ToMinorUnit_OK(t *testing.T) {
 	assert := assert.New(t)
 
-	rs, err := currency.AmountToAmountInCents("SGD", 25.12)
+	rs, err := currency.ToMinorUnit("SGD", 25.12)
 	assert.NoError(err)
 	assert.EqualValues(2512, rs)
 
-	rs, err = currency.AmountToAmountInCents("SGD", 25.123)
+	rs, err = currency.ToMinorUnit("SGD", 25.123)
 	assert.NoError(err)
 	assert.EqualValues(2512, rs)
 
-	rs, err = currency.AmountToAmountInCents("BHD", 25.123)
+	rs, err = currency.ToMinorUnit("BHD", 25.123)
 	assert.NoError(err)
 	assert.EqualValues(25123, rs)
 
-	rs, err = currency.AmountToAmountInCents("BHD", 25.1234)
+	rs, err = currency.ToMinorUnit("BHD", 25.1234)
 	assert.NoError(err)
 	assert.EqualValues(25123, rs)
 
-	rs, err = currency.AmountToAmountInCents("VND", 25.12345)
+	rs, err = currency.ToMinorUnit("VND", 25.12345)
 	assert.NoError(err)
 	assert.EqualValues(25, rs)
 
-	rs, err = currency.AmountToAmountInCents("Vnd", 25.12345)
+	rs, err = currency.ToMinorUnit("Vnd", 25.12345)
 	assert.NoError(err)
 	assert.EqualValues(25, rs)
 }
 
-func Test_AmountToAmountInCents_InvalidCurrency(t *testing.T) {
+func Test_ToMinorUnit_InvalidCurrency(t *testing.T) {
 	assert := assert.New(t)
 
-	rs, err := currency.AmountToAmountInCents("", 25.12)
+	rs, err := currency.ToMinorUnit("", 25.12)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not a valid ISO 4217 currency code")
 	assert.Zero(rs)
 
-	rs, err = currency.AmountToAmountInCents("sg", 25.12)
+	rs, err = currency.ToMinorUnit("sg", 25.12)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not a valid ISO 4217 currency code")
 	assert.Zero(rs)
 
-	rs, err = currency.AmountToAmountInCents(" ", 25.12)
+	rs, err = currency.ToMinorUnit(" ", 25.12)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not a valid ISO 4217 currency code")
 	assert.Zero(rs)
 
-	rs, err = currency.AmountToAmountInCents("      ", 25.12)
+	rs, err = currency.ToMinorUnit("      ", 25.12)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not a valid ISO 4217 currency code")
 	assert.Zero(rs)
 }
 
-func Test_AmountToAmountInCents_ZeroAmount(t *testing.T) {
+func Test_ToMinorUnit_ZeroAmount(t *testing.T) {
 	assert := assert.New(t)
 
-	rs, err := currency.AmountToAmountInCents("SGD", 0)
+	rs, err := currency.ToMinorUnit("SGD", 0)
 	assert.NoError(err)
 	assert.Zero(rs)
 }
 
-func Test_AmountToAmountInCents_InvalidAmount(t *testing.T) {
+func Test_ToMinorUnit_InvalidAmount(t *testing.T) {
 	assert := assert.New(t)
 
-	rs, err := currency.AmountToAmountInCents("USD", -0.0001)
+	rs, err := currency.ToMinorUnit("USD", -0.0001)
 	assert.Error(err)
 	assert.Contains(err.Error(), "invalid amount")
 	assert.Zero(rs)
 
-	rs, err = currency.AmountToAmountInCents("SGd", -0.0001)
+	rs, err = currency.ToMinorUnit("SGd", -0.0001)
 	assert.Error(err)
 	assert.Contains(err.Error(), "invalid amount")
 	assert.Zero(rs)
 }
 
-func Test_AmountInCentsToAmount_Ok(t *testing.T) {
+func Test_FromMinorUnit_OK(t *testing.T) {
 	assert := assert.New(t)
 
-	rs, err := currency.AmountInCentsToAmount("SGD", 2512)
+	rs, err := currency.FromMinorUnit("SGD", 2512)
 	assert.NoError(err)
 	assert.EqualValues(25.12, rs)
 
-	rs, err = currency.AmountInCentsToAmount("SGD", 25123)
+	rs, err = currency.FromMinorUnit("SGD", 25123)
 	assert.NoError(err)
 	assert.EqualValues(251.23, rs)
 
-	rs, err = currency.AmountInCentsToAmount("BHD", 25123)
+	rs, err = currency.FromMinorUnit("BHD", 25123)
 	assert.NoError(err)
 	assert.EqualValues(25.123, rs)
 
-	rs, err = currency.AmountInCentsToAmount("BHD", 251234)
+	rs, err = currency.FromMinorUnit("BHD", 251234)
 	assert.NoError(err)
 	assert.EqualValues(251.234, rs)
 
-	rs, err = currency.AmountInCentsToAmount("VND", 2512345)
+	rs, err = currency.FromMinorUnit("VND", 2512345)
 	assert.NoError(err)
 	assert.EqualValues(2512345, rs)
 
-	rs, err = currency.AmountInCentsToAmount("Vnd", 2512345)
+	rs, err = currency.FromMinorUnit("Vnd", 2512345)
 	assert.NoError(err)
 	assert.EqualValues(2512345, rs)
 }
 
-func Test_AmountInCentsToAmount_InvalidCurrency(t *testing.T) {
+func Test_FromMinorUnit_InvalidCurrency(t *testing.T) {
 	assert := assert.New(t)
 
-	rs, err := currency.AmountInCentsToAmount("", 2512)
+	rs, err := currency.FromMinorUnit("", 2512)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not a valid ISO 4217 currency code")
 	assert.Zero(rs)
 
-	rs, err = currency.AmountInCentsToAmount("sg", 2512)
+	rs, err = currency.FromMinorUnit("sg", 2512)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not a valid ISO 4217 currency code")
 	assert.Zero(rs)
 
-	rs, err = currency.AmountInCentsToAmount(" ", 2512)
+	rs, err = currency.FromMinorUnit(" ", 2512)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not a valid ISO 4217 currency code")
 	assert.Zero(rs)
 
-	rs, err = currency.AmountInCentsToAmount("      ", 2512)
+	rs, err = currency.FromMinorUnit("      ", 2512)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not a valid ISO 4217 currency code")
 	assert.Zero(rs)
 }
 
-func Test_AmountInCentsToAmount_ZeroAmount(t *testing.T) {
+func Test_FromMinorUnit_ZeroAmount(t *testing.T) {
 	assert := assert.New(t)
 
-	rs, err := currency.AmountInCentsToAmount("USD", 0)
+	rs, err := currency.FromMinorUnit("USD", 0)
 	assert.NoError(err)
 	assert.Zero(rs)
 
-	rs, err = currency.AmountInCentsToAmount("SGD", 0)
+	rs, err = currency.FromMinorUnit("SGD", 0)
 	assert.NoError(err)
 	assert.Zero(rs)
 }

--- a/currency/go.mod
+++ b/currency/go.mod
@@ -1,5 +1,11 @@
 module github.com/wego/pkg/currency
 
-go 1.16
+go 1.17
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)


### PR DESCRIPTION
- Add `UGX` to full value currency list
- Sort the list by alphabet to help manually checking easier
- [Breaking changes] Rename functions
  - `AmountToAmountInCents` to `ToMinorUnit`
  - `AmountInCentsToAmount` to `FromMinorUnit`