### PR TITLE
Fix breaking change in validator lib & separate bind JSON functions

### DIFF
--- a/http/binding/binding.go
+++ b/http/binding/binding.go
@@ -11,21 +11,25 @@ import (
 	"github.com/wego/pkg/errors"
 )
 
-// BindJSON Bind general json request
-func BindJSON(c *gin.Context, ctxKey string, request interface{}) (err error) {
-	// try to get from context
+// ShouldBindJSON binds general JSON request. It will ignore request without body.
+func ShouldBindJSON(c *gin.Context, ctxKey string, request interface{}) error {
 	if fromContext(c, ctxKey, request) {
-		return
+		return nil
 	}
 
-	// try to bind from request & set to context if ok
 	if c.Request.Body != nil && c.Request.Body != http.NoBody {
-		if err = c.ShouldBindJSON(request); err != nil {
-			return errors.New(errors.BadRequest, err)
-		}
-		c.Set(ctxKey, request)
+		return bindJSON(c, ctxKey, request)
 	}
-	return
+	return nil
+}
+
+// BindJSON binds general JSON request. It will return error if request doesn't have body.
+func BindJSON(c *gin.Context, ctxKey string, request interface{}) error {
+	if fromContext(c, ctxKey, request) {
+		return nil
+	}
+
+	return bindJSON(c, ctxKey, request)
 }
 
 // BindQuery Bind general form request
@@ -87,4 +91,13 @@ func fromContext(c *gin.Context, ctxKey string, value interface{}) bool {
 		}
 	}
 	return false
+}
+
+// bindJSON tries to bind JSON object from request body & set to context if ok
+func bindJSON(c *gin.Context, ctxKey string, request interface{}) (err error) {
+	if err = c.ShouldBindJSON(request); err != nil {
+		return errors.New(errors.BadRequest, err)
+	}
+	c.Set(ctxKey, request)
+	return
 }

--- a/http/binding/go.mod
+++ b/http/binding/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
-	github.com/go-playground/validator/v10 v10.11.0 // indirect
+	github.com/go-playground/validator/v10 v10.10.0 // indirect
 	github.com/goccy/go-json v0.9.10 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/http/binding/go.sum
+++ b/http/binding/go.sum
@@ -54,6 +54,7 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/jYrnRPArHwAcmLoJZxyho=
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-playground/validator/v10 v10.10.0 h1:I7mrTYv78z8k8VXa/qJlOlEXn/nBh+BF8dHX5nt/dr0=
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
 github.com/go-playground/validator/v10 v10.11.0 h1:0W+xRM511GY47Yy3bZUbJVitCNg2BOGlCyvTqsp/xIw=
 github.com/go-playground/validator/v10 v10.11.0/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=


### PR DESCRIPTION
- Downgrade `validator` version because it breaks our unit test
- Separate `ShouldBindJSON` (request body is optional) & `BindJSON` (request body is required)