### PR TITLE
Add DeDup function

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -1,7 +1,7 @@
 package collection
 
-// DeDup returns the input slice after removing duplicated items
-func DeDup[T comparable](in []T) (out []T) {
+// Dedup returns the input slice after removing duplicated items
+func Dedup[T comparable](in []T) (out []T) {
 	keys := make(map[T]bool)
 	for _, v := range in {
 		if found, _ := keys[v]; !found {

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -1,0 +1,13 @@
+package collection
+
+// DeDup returns the input slice after removing duplicated items
+func DeDup[T comparable](in []T) (out []T) {
+	keys := make(map[T]bool)
+	for _, v := range in {
+		if found, _ := keys[v]; !found {
+			keys[v] = true
+			out = append(out, v)
+		}
+	}
+	return
+}

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -1,0 +1,42 @@
+package collection_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wego/pkg/collection"
+)
+
+func Test_DeDup(t *testing.T) {
+	as := assert.New(t)
+
+	stringOut := collection.DeDup([]string{"b", "a", "b", "c"})
+	as.ElementsMatch(stringOut, []string{"a", "b", "c"})
+
+	intOut := collection.DeDup([]int{3, 1, 2, 1, 2, 3, 3})
+	as.ElementsMatch(intOut, []int{1, 2, 3})
+
+	floatOut := collection.DeDup([]float64{3.1, 1.2, 2.3, 1.2, 3.1})
+	as.ElementsMatch(floatOut, []float64{1.2, 2.3, 3.1})
+
+	boolOut := collection.DeDup([]bool{true, false, false, true, true})
+	as.ElementsMatch(boolOut, []bool{true, false})
+
+	type comparableStruct struct {
+		i int
+		f float64
+		s string
+		b bool
+	}
+	structIn := []comparableStruct{
+		{1, 1.0, "1", true},
+		{2, 2.0, "2", true},
+		{1, 1.0, "1", true},
+	}
+	expectedStructOut := []comparableStruct{
+		{1, 1.0, "1", true},
+		{2, 2.0, "2", true},
+	}
+	structOut := collection.DeDup(structIn)
+	as.ElementsMatch(structOut, expectedStructOut)
+}

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -7,19 +7,19 @@ import (
 	"github.com/wego/pkg/collection"
 )
 
-func Test_DeDup(t *testing.T) {
+func Test_Dedup(t *testing.T) {
 	as := assert.New(t)
 
-	stringOut := collection.DeDup([]string{"b", "a", "b", "c"})
+	stringOut := collection.Dedup([]string{"b", "a", "b", "c"})
 	as.ElementsMatch(stringOut, []string{"a", "b", "c"})
 
-	intOut := collection.DeDup([]int{3, 1, 2, 1, 2, 3, 3})
+	intOut := collection.Dedup([]int{3, 1, 2, 1, 2, 3, 3})
 	as.ElementsMatch(intOut, []int{1, 2, 3})
 
-	floatOut := collection.DeDup([]float64{3.1, 1.2, 2.3, 1.2, 3.1})
+	floatOut := collection.Dedup([]float64{3.1, 1.2, 2.3, 1.2, 3.1})
 	as.ElementsMatch(floatOut, []float64{1.2, 2.3, 3.1})
 
-	boolOut := collection.DeDup([]bool{true, false, false, true, true})
+	boolOut := collection.Dedup([]bool{true, false, false, true, true})
 	as.ElementsMatch(boolOut, []bool{true, false})
 
 	type comparableStruct struct {
@@ -37,6 +37,6 @@ func Test_DeDup(t *testing.T) {
 		{1, 1.0, "1", true},
 		{2, 2.0, "2", true},
 	}
-	structOut := collection.DeDup(structIn)
+	structOut := collection.Dedup(structIn)
 	as.ElementsMatch(structOut, expectedStructOut)
 }

--- a/collection/go.mod
+++ b/collection/go.mod
@@ -1,5 +1,11 @@
 module github.com/wego/pkg/collection
 
-go 1.16
+go 1.18
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)


### PR DESCRIPTION
Adding a function to deduplicate a slice of `comaprable` items.

`comparable` types: booleans, numbers, strings, pointers, channels, arrays of comparable types, structs whose fields are all comparable types