### PR TITLE
Refactor currency pkg

### DIFF
--- a/auto_version
+++ b/auto_version
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 POSITIONAL=()
-update_path_version=true
+update_patch_version=true
 update_major_version=false
 update_minor_version=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-  -p | --path)
-    update_path_version=true
+  -p | --patch)
+    update_patch_version=true
     shift 1
     ;;
   -m | --major)
@@ -73,7 +73,7 @@ for dir in $(find . -name 'go.mod' -exec dirname {} \; | sort -u); do
   fi
 
   if [ "$changes" -gt 0 ]; then
-    [[ $update_path_version == true ]] && patch_version=$((patch_version + 1))
+    [[ $update_patch_version == true ]] && patch_version=$((patch_version + 1))
     [[ $update_minor_version == true ]] && minor_version=$((minor_version + 1)) && patch_version=0
     [[ $update_major_version == true ]] && major_version=$((major_version + 1)) && minor_version=0 && patch_version=0
     [[ $first_version == true ]] && major_version=0 && minor_version=1 && patch_version=0

--- a/currency/currency.go
+++ b/currency/currency.go
@@ -46,9 +46,9 @@ var iso4217Currencies = map[string]bool{
 }
 
 //  https://www.checkout.com/docs/resources/calculating-the-value
-const defaultCurrencyFactor = 100
+const defaultCurrencyFactor float64 = 100
 
-var currencyFactors = map[string]uint{
+var currencyFactors = map[string]float64{
 	// Currencies have full value
 	"BIF": 1, // Burundian Franc
 	"CLF": 1, // Chilean Unidad de Fomentos
@@ -87,7 +87,7 @@ func ToMinorUnit(currencyCode string, amount float64) (minorUnitAmount uint64, e
 	switch {
 	case amount > 0:
 		factor := getCurrencyFactor(currencyCode)
-		minorUnitAmount = uint64(math.Round(amount * float64(factor)))
+		minorUnitAmount = uint64(math.Round(amount * factor))
 	case amount == 0:
 		minorUnitAmount = 0
 	default:
@@ -102,16 +102,11 @@ func FromMinorUnit(currencyCode string, minorUnitAmount uint64) (amount float64,
 		err = fmt.Errorf("%s is not a valid ISO 4217 currency code", currencyCode)
 		return
 	}
-	switch {
-	case minorUnitAmount > 0:
+
+	if minorUnitAmount > 0 {
 		factor := getCurrencyFactor(currencyCode)
-		amount = float64(minorUnitAmount) / float64(factor)
-		amount = math.Round(amount*float64(factor)) / float64(factor)
-		return
-	case minorUnitAmount == 0:
-		amount = 0
-	default:
-		err = fmt.Errorf("invalid amount: %f", amount)
+		amount = float64(minorUnitAmount) / factor
+		amount = math.Round(amount*factor) / factor
 	}
 	return
 }
@@ -121,7 +116,7 @@ func IsISO4217(code string) bool {
 	return iso4217Currencies[strings.ToUpper(strings.TrimSpace(code))]
 }
 
-func getCurrencyFactor(currency string) (factor uint) {
+func getCurrencyFactor(currency string) (factor float64) {
 	factor, ok := currencyFactors[strings.ToUpper(currency)]
 	if !ok {
 		factor = defaultCurrencyFactor

--- a/currency/currency.go
+++ b/currency/currency.go
@@ -81,16 +81,13 @@ var currencyFactors = map[string]float64{
 // https://en.wikipedia.org/wiki/ISO_4217#Minor_units_of_currency
 func ToMinorUnit(currencyCode string, amount float64) (minorUnitAmount uint64, err error) {
 	if !IsISO4217(currencyCode) {
-		err = fmt.Errorf("%s is not a valid ISO 4217 currency code", currencyCode)
-		return
+		return 0, fmt.Errorf("%s is not a valid ISO 4217 currency code", currencyCode)
 	}
 	switch {
 	case amount > 0:
 		factor := getCurrencyFactor(currencyCode)
 		minorUnitAmount = uint64(math.Round(amount * factor))
-	case amount == 0:
-		minorUnitAmount = 0
-	default:
+	case amount < 0:
 		err = fmt.Errorf("invalid amount: %f", amount)
 	}
 	return
@@ -99,8 +96,7 @@ func ToMinorUnit(currencyCode string, amount float64) (minorUnitAmount uint64, e
 // FromMinorUnit converts amount in the smallest unit (minor unit) of a currency to amount in that currency
 func FromMinorUnit(currencyCode string, minorUnitAmount uint64) (amount float64, err error) {
 	if !IsISO4217(currencyCode) {
-		err = fmt.Errorf("%s is not a valid ISO 4217 currency code", currencyCode)
-		return
+		return 0, fmt.Errorf("%s is not a valid ISO 4217 currency code", currencyCode)
 	}
 
 	if minorUnitAmount > 0 {

--- a/currency/currency_test.go
+++ b/currency/currency_test.go
@@ -95,9 +95,9 @@ func Test_ToMinorUnit_InvalidAmount(t *testing.T) {
 func Test_FromMinorUnit_OK(t *testing.T) {
 	assert := assert.New(t)
 
-	rs, err := currency.FromMinorUnit("SGD", 2512)
+	rs, err := currency.FromMinorUnit("SGD", 2599)
 	assert.NoError(err)
-	assert.EqualValues(25.12, rs)
+	assert.EqualValues(25.99, rs)
 
 	rs, err = currency.FromMinorUnit("SGD", 25123)
 	assert.NoError(err)
@@ -107,9 +107,9 @@ func Test_FromMinorUnit_OK(t *testing.T) {
 	assert.NoError(err)
 	assert.EqualValues(25.123, rs)
 
-	rs, err = currency.FromMinorUnit("BHD", 251234)
+	rs, err = currency.FromMinorUnit("BHD", 251987)
 	assert.NoError(err)
-	assert.EqualValues(251.234, rs)
+	assert.EqualValues(251.987, rs)
 
 	rs, err = currency.FromMinorUnit("VND", 2512345)
 	assert.NoError(err)
@@ -151,7 +151,11 @@ func Test_FromMinorUnit_ZeroAmount(t *testing.T) {
 	assert.NoError(err)
 	assert.Zero(rs)
 
-	rs, err = currency.FromMinorUnit("SGD", 0)
+	rs, err = currency.FromMinorUnit("VND", 0)
+	assert.NoError(err)
+	assert.Zero(rs)
+
+	rs, err = currency.FromMinorUnit("KWD", 0)
 	assert.NoError(err)
 	assert.Zero(rs)
 }

--- a/currency/go.mod
+++ b/currency/go.mod
@@ -1,6 +1,6 @@
 module github.com/wego/pkg/currency
 
-go 1.17
+go 1.18
 
 require github.com/stretchr/testify v1.7.0
 


### PR DESCRIPTION
- Remove redundant code
- Change `factor` to `float64` to avoid type casting
- Fix typo in `auto_version` script