### PR TITLE
Use builtin `big.Int` function instead of custom `zeroPad`

### DIFF
--- a/encryption/ecies/keys.go
+++ b/encryption/ecies/keys.go
@@ -51,23 +51,9 @@ func defaultKDF(secret []byte) ([]byte, error) {
 }
 
 func keySize(curve elliptic.Curve) int {
-	bitSize := curve.Params().BitSize
-
-	size := bitSize / 8
-	if bitSize%8 > 0 {
-		size++
-	}
-	return size
+	return (curve.Params().BitSize + 7) / 8
 }
 
 func publicKeySize(keySize int) int {
 	return keySize*2 + 1
-}
-
-func zeroPad(b []byte, length int) []byte {
-	if len(b) < length {
-		b = append(make([]byte, length-len(b)), b...)
-	}
-
-	return b
 }

--- a/encryption/ecies/publickey.go
+++ b/encryption/ecies/publickey.go
@@ -1,7 +1,6 @@
 package ecies
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
@@ -110,11 +109,13 @@ func PublicKeyFromPEMBytes(bytes []byte) (*PublicKey, error) {
 // https://secg.org/sec1-v2.pdf#subsubsection.2.3.3
 func (pub *PublicKey) Bytes() []byte {
 	size := keySize(pub.curve)
+	ret := make([]byte, 1+2*size)
+	ret[0] = 0x04 // uncompressed point
 
-	x := zeroPad(pub.X.Bytes(), size)
-	y := zeroPad(pub.Y.Bytes(), size)
-
-	return bytes.Join([][]byte{{0x04}, x, y}, nil)
+	// the FillBytes function will pad the bytes with 0s
+	pub.X.FillBytes(ret[1 : 1+size])
+	pub.Y.FillBytes(ret[1+size : 1+2*size])
+	return ret
 }
 
 // Base64 returns public key bytes in base64 form


### PR DESCRIPTION
Approach:
~~When generate from a elliptic curve, the `(x, y)` can be negative, when convert, the sign bit will be stored which will cause the actual bytes length exceeds the calculated keySize. 
Just use the abs value, since we are on a `elliptic curve`, the point still valid.~~

Use builtin function instead of custom `zeroPad`