### PR TITLE
Fix `datetime` `null` error

### DIFF
--- a/datetime/epochtime.go
+++ b/datetime/epochtime.go
@@ -15,15 +15,13 @@ type EpochTime time.Time
 
 // UnmarshalJSON Parses the json string epoch time to time.Time
 func (e *EpochTime) UnmarshalJSON(b []byte) (err error) {
-	s := strings.Trim(string(b), "\"")
-	if strings.ToLower(s) == nullString {
+	var epoch int64
+
+	epoch, err = parseEpochTime(b)
+	if err != nil || epoch == 0 {
 		return
 	}
-	epoch, err := strconv.ParseInt(s, 10, 64)
-	convertedTime := time.UnixMilli(epoch)
-
-	*e = EpochTime(convertedTime)
-
+	*e = EpochTime(time.UnixMilli(epoch))
 	return
 }
 
@@ -32,14 +30,21 @@ type EpochTimeSeconds time.Time
 
 // UnmarshalJSON Parses the json string epoch time to time.Time
 func (e *EpochTimeSeconds) UnmarshalJSON(b []byte) (err error) {
-	s := strings.Trim(string(b), "\"")
-	if strings.ToLower(s) == nullString {
+	var epoch int64
+
+	epoch, err = parseEpochTime(b)
+	if err != nil || epoch == 0 {
 		return
 	}
-	epoch, err := strconv.ParseInt(s, 10, 64)
-	convertedTime := time.Unix(epoch, 0)
+	*e = EpochTimeSeconds(time.Unix(epoch, 0))
+	return
+}
 
-	*e = EpochTimeSeconds(convertedTime)
-
+func parseEpochTime(b []byte) (epoch int64, err error) {
+	s := strings.Trim(string(b), "\"")
+	if strings.ToLower(s) != nullString {
+		epoch, err = strconv.ParseInt(s, 10, 64)
+		return
+	}
 	return
 }


### PR DESCRIPTION
When value is `null` should not parse time any more