### PR TITLE
Add FormatAmount func to format only the amount

### DIFF
--- a/currency/currency.go
+++ b/currency/currency.go
@@ -148,7 +148,7 @@ func GetCurrencyFactor(currency string) (factor float64) {
 	return
 }
 
-// decimalPlaces returns the number of decimalPlaces after the decimal point
+// decimalPlaces returns the number of digits after the decimal point
 func decimalPlaces(currencyCode string) uint8 {
 	return uint8(math.Log10(GetCurrencyFactor(currencyCode)))
 }

--- a/currency/currency.go
+++ b/currency/currency.go
@@ -114,7 +114,8 @@ func IsISO4217(code string) bool {
 	return iso4217Currencies[strings.ToUpper(strings.TrimSpace(code))]
 }
 
-// Format formats a currency amount in given locale. Empty or invalid locale will be fallback to "en".
+// Format formats a currency amount for display purpose in given locale.
+// Empty or invalid locale will be fallback to "en".
 func Format(amount float64, currencyCode string, locale string) (string, error) {
 	if locale == "" {
 		locale = "en"
@@ -126,8 +127,15 @@ func Format(amount float64, currencyCode string, locale string) (string, error) 
 	}
 	loc := currency.NewLocale(locale)
 	formatter := currency.NewFormatter(loc)
-	formatter.MaxDigits = uint8(math.Log10(GetCurrencyFactor(currencyCode)))
+	formatter.MaxDigits = digits(currencyCode)
 	return formatter.Format(amt), nil
+}
+
+// FormatAmount formats a currency amount without the currency symbol & grouping separator
+func FormatAmount(amount float64, currencyCode string) string {
+	d := digits(currencyCode)
+	f := fmt.Sprintf("%%.%df", d)
+	return fmt.Sprintf(f, amount)
 }
 
 // GetCurrencyFactor returns the currency factor
@@ -137,4 +145,9 @@ func GetCurrencyFactor(currency string) (factor float64) {
 		factor = defaultCurrencyFactor
 	}
 	return
+}
+
+// digits returns the number of digits after the decimal point
+func digits(currencyCode string) uint8 {
+	return uint8(math.Log10(GetCurrencyFactor(currencyCode)))
 }

--- a/currency/currency.go
+++ b/currency/currency.go
@@ -1,3 +1,4 @@
+// Package currency provides functions to convert & format currency amount.
 package currency
 
 import (
@@ -115,7 +116,7 @@ func IsISO4217(code string) bool {
 }
 
 // Format formats a currency amount for display purpose in given locale.
-// Empty or invalid locale will be fallback to "en".
+// Empty or invalid locale will fallback to "en".
 func Format(amount float64, currencyCode string, locale string) (string, error) {
 	if locale == "" {
 		locale = "en"
@@ -127,13 +128,13 @@ func Format(amount float64, currencyCode string, locale string) (string, error) 
 	}
 	loc := currency.NewLocale(locale)
 	formatter := currency.NewFormatter(loc)
-	formatter.MaxDigits = digits(currencyCode)
+	formatter.MaxDigits = decimalPlaces(currencyCode)
 	return formatter.Format(amt), nil
 }
 
 // FormatAmount formats a currency amount without the currency symbol & grouping separator
 func FormatAmount(amount float64, currencyCode string) string {
-	d := digits(currencyCode)
+	d := decimalPlaces(currencyCode)
 	f := fmt.Sprintf("%%.%df", d)
 	return fmt.Sprintf(f, amount)
 }
@@ -147,7 +148,7 @@ func GetCurrencyFactor(currency string) (factor float64) {
 	return
 }
 
-// digits returns the number of digits after the decimal point
-func digits(currencyCode string) uint8 {
+// decimalPlaces returns the number of decimalPlaces after the decimal point
+func decimalPlaces(currencyCode string) uint8 {
 	return uint8(math.Log10(GetCurrencyFactor(currencyCode)))
 }

--- a/currency/currency_test.go
+++ b/currency/currency_test.go
@@ -236,6 +236,55 @@ func Test_Format(t *testing.T) {
 	}
 }
 
+func Test_FormatAmount(t *testing.T) {
+	for n, tc := range map[string]struct {
+		currencyCode string
+		amount       float64
+		want         string
+	}{
+		"Invalid currency": {
+			currencyCode: "SG",
+			amount:       2048.172,
+			want:         "2048.17",
+		},
+		"SGD": {
+			currencyCode: "SGD",
+			amount:       252.2048,
+			want:         "252.20",
+		},
+		"USD round up": {
+			currencyCode: "USD",
+			amount:       2048.1758,
+			want:         "2048.18",
+		},
+		"BHD": {
+			currencyCode: "BHD",
+			amount:       2048.256432,
+			want:         "2048.256",
+		},
+		"KWD round up": {
+			currencyCode: "KWD",
+			amount:       267.251678,
+			want:         "267.252",
+		},
+		"JPY": {
+			currencyCode: "JPY",
+			amount:       272500.423,
+			want:         "272500",
+		},
+		"VND round up": {
+			currencyCode: "VND",
+			amount:       262500000.523,
+			want:         "262500001",
+		},
+	} {
+		t.Run(n, func(tt *testing.T) {
+			got := currency.FormatAmount(tc.amount, tc.currencyCode)
+			assert.Equal(tt, tc.want, got)
+		})
+	}
+}
+
 func Test_GetCurrencyFactor(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
There are some use cases in which we only want to format the amount without the currency or the grouping separator.

I created a function for that purpose.
Can see the unit test for more clarification.