### PR TITLE
errors: Extend `Error` type to include contexts

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -2,11 +2,11 @@ package errors
 
 import (
 	"context"
-	"maps"
 	"net/http"
 
 	goErrors "errors"
 
+	"github.com/wego/pkg/collection"
 	"github.com/wego/pkg/common"
 	"gorm.io/gorm"
 )
@@ -168,7 +168,7 @@ func (e *Error) propagateContexts() {
 			basics = common.Basics{}
 		}
 
-		maps.Copy(basics, subBasics)
+		collection.Copy(basics, subBasics)
 		e.ctx[ctxBasics] = basics
 	}
 
@@ -179,7 +179,7 @@ func (e *Error) propagateContexts() {
 			extras = common.Extras{}
 		}
 
-		maps.Copy(extras, subExtras)
+		collection.Copy(extras, subExtras)
 		e.ctx[ctxExtras] = extras
 	}
 

--- a/errors/error.go
+++ b/errors/error.go
@@ -186,12 +186,12 @@ func (e *Error) propagateContexts() {
 	subErr.ctx = nil
 }
 
-func (e *Error) getBasics() common.Basics {
+func (e *Error) basics() common.Basics {
 	basics, _ := e.ctx[ctxBasics].(common.Basics)
 	return basics
 }
 
-func (e *Error) getExtras() common.Extras {
+func (e *Error) extras() common.Extras {
 	extras, _ := e.ctx[ctxExtras].(common.Extras)
 	return extras
 }

--- a/errors/error.go
+++ b/errors/error.go
@@ -1,10 +1,13 @@
 package errors
 
 import (
+	"context"
+	"maps"
 	"net/http"
 
 	goErrors "errors"
 
+	"github.com/wego/pkg/common"
 	"gorm.io/gorm"
 )
 
@@ -20,6 +23,7 @@ type Error struct {
 	Kind Kind
 	Err  error
 	msg  string
+	ctx  map[string]any
 }
 
 // error kinds
@@ -37,6 +41,11 @@ const (
 	NotImplemented  Kind = -3 // NotImplemented The requested action/resource is not implemented
 )
 
+const (
+	ctxBasics = "basics"
+	ctxExtras = "extras"
+)
+
 // sentry keys
 const (
 	SentryErrorCode  = "error_code"
@@ -46,14 +55,27 @@ const (
 
 var (
 	// ErrNotSupported the requested action/resource is not supported
-	ErrNotSupported = New(NotSupported, "not supported")
+	ErrNotSupported = New(nil, NotSupported, "not supported")
 	// ErrNotImplemented the requested action/resource is not implemented
-	ErrNotImplemented = New(NotImplemented, "not implemented")
+	ErrNotImplemented = New(nil, NotImplemented, "not implemented")
 )
 
 // New construct a new error, default having kind Unexpected
-func New(args ...interface{}) error {
-	e := &Error{}
+func New(ctx context.Context, args ...interface{}) error {
+	e := &Error{
+		ctx: map[string]any{},
+	}
+
+	basics := common.GetBasics(ctx)
+	if basics != nil {
+		e.ctx[ctxBasics] = basics
+	}
+
+	extras := common.GetExtras(ctx)
+	if extras != nil {
+		e.ctx[ctxExtras] = extras
+	}
+
 	for _, arg := range args {
 		switch arg := arg.(type) {
 		case int:
@@ -64,6 +86,7 @@ func New(args ...interface{}) error {
 			e.Kind = arg
 		case error:
 			e.Err = arg
+			e.propagateContexts()
 		case string:
 			e.msg = arg
 		}
@@ -120,12 +143,55 @@ func ops(e *Error) []Op {
 // WrapGORMError wraps an GORM error into our error such as adding errors.Kind
 func WrapGORMError(op Op, err error) error {
 	if goErrors.Is(err, gorm.ErrRecordNotFound) {
-		return New(op, NotFound, err)
+		return New(nil, op, NotFound, err)
 	}
 
 	if goErrors.Is(err, gorm.ErrDuplicatedKey) {
-		return New(op, Conflict, err)
+		return New(nil, op, Conflict, err)
 	}
 
-	return New(op, err)
+	return New(nil, op, err)
+}
+
+// propagateContexts combines the "basics" and "extras" contexts from the child error into the parent, so that the
+// key-values propagate upwards to the top level error.
+func (e *Error) propagateContexts() {
+	subErr, ok := e.Err.(*Error)
+	if !ok {
+		return
+	}
+
+	subBasics, _ := subErr.ctx[ctxBasics].(common.Basics)
+	if subBasics != nil {
+		basics, basicsOK := e.ctx[ctxBasics].(common.Basics)
+		if !basicsOK {
+			basics = common.Basics{}
+		}
+
+		maps.Copy(basics, subBasics)
+		e.ctx[ctxBasics] = basics
+	}
+
+	subExtras, _ := subErr.ctx[ctxExtras].(common.Extras)
+	if subExtras != nil {
+		extras, extrasOK := e.ctx[ctxExtras].(common.Extras)
+		if !extrasOK {
+			extras = common.Extras{}
+		}
+
+		maps.Copy(extras, subExtras)
+		e.ctx[ctxExtras] = extras
+	}
+
+	subErr.ctx = nil
+}
+
+func (e *Error) getBasics() common.Basics {
+	basics, _ := e.ctx[ctxBasics].(common.Basics)
+	return basics
+}
+
+func (e *Error) getExtras() common.Extras {
+	extras, _ := e.ctx[ctxExtras].(common.Extras)
+	return extras
 }

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -1,0 +1,143 @@
+package errors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wego/pkg/common"
+)
+
+const (
+	parentOp         = "parent op"
+	parentErrMsg     = "parent error message"
+	childOp          = "child op"
+	childErrMsg      = "child error message"
+	grandchildOp     = "grandchild op"
+	grandchildErrMsg = "grandchild error message"
+)
+
+func TestNew_NestedContext_ParentContext(t *testing.T) {
+	assert := assert.New(t)
+	ctx0 := context.Background()
+
+	ctx1 := context.WithValue(ctx0, "keyNotStored1", "valueNotStored1")
+	ctx1 = common.SetBasics(ctx1, common.Basics{"key1": "value1"})
+
+	ctx2 := context.WithValue(ctx1, "keyNotStored2", "valueNotStored2")
+	ctx2 = common.SetBasics(ctx2, common.Basics{"key1": "value1-replaced"})
+	ctx2 = common.SetExtras(ctx2, common.Extras{"key2": "value2"})
+
+	childErr2 := New(ctx2, Op(grandchildOp), NotFound, grandchildErrMsg)
+	childErr1 := New(ctx1, Op(childOp), BadRequest, childErrMsg, childErr2)
+	gotErr := New(ctx0, Op(parentOp), parentErrMsg, childErr1)
+
+	wantErr := &Error{
+		Op:  parentOp,
+		msg: parentErrMsg,
+		Err: &Error{
+			Op:   childOp,
+			Kind: BadRequest,
+			msg:  childErrMsg,
+			Err: &Error{
+				Op:   grandchildOp,
+				Kind: NotFound,
+				msg:  grandchildErrMsg,
+			},
+		},
+		ctx: map[string]any{
+			"basics": common.Basics{
+				"key1": "value1-replaced",
+			},
+			"extras": common.Extras{
+				"key2": "value2",
+			},
+		},
+	}
+
+	assert.Equal(wantErr, gotErr)
+}
+
+func TestNew_NestedContext_ChildsOwnContext(t *testing.T) {
+	assert := assert.New(t)
+
+	// Child setting their own `context.Background()`
+	ctx1 := context.WithValue(context.Background(), "keyNotStored1", "valueNotStored1")
+	ctx1 = common.SetBasics(ctx1, common.Basics{"key1": "value1"})
+
+	// Child setting their own `context.Background()`
+	ctx2 := context.WithValue(context.Background(), "keyNotStored2", "valueNotStored2")
+	ctx2 = common.SetBasics(ctx2, common.Basics{"key1": "value1-replaced"})
+	ctx2 = common.SetExtras(ctx2, common.Extras{"key2": "value2"})
+
+	childErr2 := New(ctx2, Op(grandchildOp), NotFound, grandchildErrMsg)
+	childErr1 := New(ctx1, Op(childOp), BadRequest, childErrMsg, childErr2)
+	gotErr := New(context.Background(), Op(parentOp), parentErrMsg, childErr1)
+
+	wantErr := &Error{
+		Op:  parentOp,
+		msg: parentErrMsg,
+		Err: &Error{
+			Op:   childOp,
+			Kind: BadRequest,
+			msg:  childErrMsg,
+			Err: &Error{
+				Op:   grandchildOp,
+				Kind: NotFound,
+				msg:  grandchildErrMsg,
+			},
+		},
+		ctx: map[string]any{
+			"basics": common.Basics{
+				"key1": "value1-replaced",
+			},
+			"extras": common.Extras{
+				"key2": "value2",
+			},
+		},
+	}
+
+	assert.Equal(wantErr, gotErr)
+}
+
+func Test_getBasics(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	childCtx := common.SetBasic(ctx, "key1", "value1")
+	childCtx = common.SetBasic(childCtx, "key2", "value2")
+	childCtx = common.SetExtra(childCtx, "key3", "value3")
+
+	childErr := New(childCtx, Op(childOp), childErrMsg)
+	err := New(ctx, Op(parentOp), "msg", childErr)
+
+	e, ok := err.(*Error)
+	assert.True(ok)
+
+	wantBasics := common.Basics{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	assert.Equal(wantBasics, e.getBasics())
+}
+
+func Test_getExtras(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	childCtx := common.SetBasic(ctx, "key1", "value1")
+	childCtx = common.SetExtra(childCtx, "key2", "value2")
+	childCtx = common.SetExtra(childCtx, "key3", "value3")
+
+	childErr := New(childCtx, Op(childOp), childErrMsg)
+	err := New(ctx, Op(parentOp), "msg", childErr)
+
+	e, ok := err.(*Error)
+	assert.True(ok)
+
+	wantExtras := common.Extras{
+		"key2": "value2",
+		"key3": "value3",
+	}
+	assert.Equal(wantExtras, e.getExtras())
+}

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -102,6 +102,33 @@ func TestNew_NestedContext_ChildsOwnContext(t *testing.T) {
 	assert.Equal(wantErr, gotErr)
 }
 
+func TestNew_NestedContext_NilChildContext(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx0 := context.Background()
+	ctx0 = common.SetBasics(ctx0, common.Basics{"key1": "value1"})
+
+	childErr1 := New(nil, Op(childOp), BadRequest, childErrMsg)
+	gotErr := New(ctx0, Op(parentOp), parentErrMsg, childErr1)
+
+	wantErr := &Error{
+		Op:  parentOp,
+		msg: parentErrMsg,
+		Err: &Error{
+			Op:   childOp,
+			Kind: BadRequest,
+			msg:  childErrMsg,
+		},
+		ctx: map[string]any{
+			"basics": common.Basics{
+				"key1": "value1",
+			},
+		},
+	}
+
+	assert.Equal(wantErr, gotErr)
+}
+
 func Test_getBasics(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -17,14 +17,16 @@ const (
 	grandchildErrMsg = "grandchild error message"
 )
 
+type testContextKey string
+
 func TestNew_NestedContext_ParentContext(t *testing.T) {
 	assert := assert.New(t)
 	ctx0 := context.Background()
 
-	ctx1 := context.WithValue(ctx0, "keyNotStored1", "valueNotStored1")
+	ctx1 := context.WithValue(ctx0, testContextKey("keyNotStored1"), "valueNotStored1")
 	ctx1 = common.SetBasics(ctx1, common.Basics{"key1": "value1"})
 
-	ctx2 := context.WithValue(ctx1, "keyNotStored2", "valueNotStored2")
+	ctx2 := context.WithValue(ctx1, testContextKey("keyNotStored2"), "valueNotStored2")
 	ctx2 = common.SetBasics(ctx2, common.Basics{"key1": "value1-replaced"})
 	ctx2 = common.SetExtras(ctx2, common.Extras{"key2": "value2"})
 
@@ -62,11 +64,11 @@ func TestNew_NestedContext_ChildsOwnContext(t *testing.T) {
 	assert := assert.New(t)
 
 	// Child setting their own `context.Background()`
-	ctx1 := context.WithValue(context.Background(), "keyNotStored1", "valueNotStored1")
+	ctx1 := context.WithValue(context.Background(), testContextKey("keyNotStored1"), "valueNotStored1")
 	ctx1 = common.SetBasics(ctx1, common.Basics{"key1": "value1"})
 
 	// Child setting their own `context.Background()`
-	ctx2 := context.WithValue(context.Background(), "keyNotStored2", "valueNotStored2")
+	ctx2 := context.WithValue(context.Background(), testContextKey("keyNotStored2"), "valueNotStored2")
 	ctx2 = common.SetBasics(ctx2, common.Basics{"key1": "value1-replaced"})
 	ctx2 = common.SetExtras(ctx2, common.Extras{"key2": "value2"})
 

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -129,7 +129,7 @@ func TestNew_NestedContext_NilChildContext(t *testing.T) {
 	assert.Equal(wantErr, gotErr)
 }
 
-func Test_getBasics(t *testing.T) {
+func Test_basics(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
@@ -147,10 +147,10 @@ func Test_getBasics(t *testing.T) {
 		"key1": "value1",
 		"key2": "value2",
 	}
-	assert.Equal(wantBasics, e.getBasics())
+	assert.Equal(wantBasics, e.basics())
 }
 
-func Test_getExtras(t *testing.T) {
+func Test_extras(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
@@ -168,5 +168,5 @@ func Test_getExtras(t *testing.T) {
 		"key2": "value2",
 		"key3": "value3",
 	}
-	assert.Equal(wantExtras, e.getExtras())
+	assert.Equal(wantExtras, e.extras())
 }

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/wego/pkg/collection v0.1.10
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/errors/go.sum
+++ b/errors/go.sum
@@ -314,6 +314,8 @@ github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBn
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/wego/pkg/collection v0.1.10 h1:DNhxePXdvHUKzI5lG3TLYBEyDsimEMZCXil8V3+Cwss=
+github.com/wego/pkg/collection v0.1.10/go.mod h1:hdWZoMhAO2auAXU0Bxzb27ABKtFXat1KSPcG/fhAMsE=
 github.com/wego/pkg/common v0.1.12 h1:RjtY5xIRK3a10BnMkKY+Hzyxh0ZyFMr2I1J9cJjfrf0=
 github.com/wego/pkg/common v0.1.12/go.mod h1:FjyQqTAvBs8MwdusdgfiSCkUt4q3fzPPlFTajKkyG1c=
 github.com/wego/pkg/env v0.1.0 h1:4sQnBbHOu4JhHwewQslp2mzx8j0vMRdC+J/V+k/t/Dg=

--- a/errors/sentry.go
+++ b/errors/sentry.go
@@ -39,7 +39,7 @@ func enrichScope(ctx context.Context, scope *sentry.Scope, err error) {
 
 	e, ok := err.(*Error)
 	if ok {
-		for key, value := range e.getBasics() {
+		for key, value := range e.basics() {
 			if tag, err := json.Marshal(value); err == nil {
 				scope.SetTag(key, string(tag))
 				fingerprint = append(fingerprint, key)
@@ -53,7 +53,7 @@ func enrichScope(ctx context.Context, scope *sentry.Scope, err error) {
 			fingerprint = append(fingerprint, string(o))
 		}
 
-		for k, v := range e.getExtras() {
+		for k, v := range e.extras() {
 			scope.SetExtra(k, v)
 		}
 	}

--- a/errors/sentry.go
+++ b/errors/sentry.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/wego/pkg/common"
 	"github.com/wego/pkg/env"
 )
 
@@ -40,8 +39,7 @@ func enrichScope(ctx context.Context, scope *sentry.Scope, err error) {
 
 	e, ok := err.(*Error)
 	if ok {
-		basics := common.GetBasics(ctx)
-		for key, value := range basics {
+		for key, value := range e.getBasics() {
 			if tag, err := json.Marshal(value); err == nil {
 				scope.SetTag(key, string(tag))
 				fingerprint = append(fingerprint, key)
@@ -55,8 +53,7 @@ func enrichScope(ctx context.Context, scope *sentry.Scope, err error) {
 			fingerprint = append(fingerprint, string(o))
 		}
 
-		extras := common.GetExtras(ctx)
-		for k, v := range extras {
+		for k, v := range e.getExtras() {
 			scope.SetExtra(k, v)
 		}
 	}


### PR DESCRIPTION
## Overview

This PR extends the `errors` package's `Error` type to include contexts. The top-level `Error` will now contain all the contexts added in the children.

It works with the `common` package to get `basics` and `extras` keys added into a given `context.Context`. This is so that we can enrich the scope in Sentry with all the relevant contexts that we need.