### PR TITLE
errors: Remove ctx from New + add WithContext method

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -92,16 +92,14 @@ func (e *Error) WithContext(ctx context.Context) *Error {
 
 	basics := common.GetBasics(ctx)
 	if basics != nil {
-		currentBasics, _ := e.ctx[ctxBasics].(common.Basics)
-		collection.Copy(basics, currentBasics)
-		e.ctx[ctxBasics] = basics
+		collection.Copy(basics, e.basics())
+		e.setBasics(basics)
 	}
 
 	extras := common.GetExtras(ctx)
 	if extras != nil {
-		currentExtras, _ := e.ctx[ctxExtras].(common.Extras)
-		collection.Copy(extras, currentExtras)
-		e.ctx[ctxExtras] = extras
+		collection.Copy(extras, e.extras())
+		e.setExtras(extras)
 	}
 
 	return e
@@ -174,31 +172,31 @@ func (e *Error) propagateContexts() {
 		return
 	}
 
-	subBasics, _ := subErr.ctx[ctxBasics].(common.Basics)
-	subExtras, _ := subErr.ctx[ctxExtras].(common.Extras)
+	subBasics := subErr.basics()
+	subExtras := subErr.extras()
 	// Only create context if there is at least one context to propagate.
 	if (subBasics != nil || subExtras != nil) && e.ctx == nil {
 		e.ctx = map[string]any{}
 	}
 
 	if subBasics != nil {
-		basics, basicsOK := e.ctx[ctxBasics].(common.Basics)
-		if !basicsOK {
+		basics := e.basics()
+		if basics == nil {
 			basics = common.Basics{}
 		}
 
 		collection.Copy(basics, subBasics)
-		e.ctx[ctxBasics] = basics
+		e.setBasics(basics)
 	}
 
 	if subExtras != nil {
-		extras, extrasOK := e.ctx[ctxExtras].(common.Extras)
-		if !extrasOK {
+		extras := e.extras()
+		if extras == nil {
 			extras = common.Extras{}
 		}
 
 		collection.Copy(extras, subExtras)
-		e.ctx[ctxExtras] = extras
+		e.setExtras(extras)
 	}
 
 	subErr.ctx = nil
@@ -209,7 +207,15 @@ func (e *Error) basics() common.Basics {
 	return basics
 }
 
+func (e *Error) setBasics(basics common.Basics) {
+	e.ctx[ctxBasics] = basics
+}
+
 func (e *Error) extras() common.Extras {
 	extras, _ := e.ctx[ctxExtras].(common.Extras)
 	return extras
+}
+
+func (e *Error) setExtras(extras common.Extras) {
+	e.ctx[ctxExtras] = extras
 }

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -21,18 +21,25 @@ type testContextKey string
 
 func TestNew_NestedContext_ParentContext(t *testing.T) {
 	assert := assert.New(t)
-	ctx0 := context.Background()
+	ctx := context.Background()
+	ctx = common.SetBasics(ctx, common.Basics{"key1": "value1-original"})
+	ctx = common.SetBasic(ctx, "key2", "value2")
 
-	ctx1 := context.WithValue(ctx0, testContextKey("keyNotStored1"), "valueNotStored1")
-	ctx1 = common.SetBasics(ctx1, common.Basics{"key1": "value1"})
+	childCtx := context.WithValue(ctx, testContextKey("keyNotStored1"), "valueNotStored1")
+	childCtx = common.SetBasics(childCtx, common.Basics{"key1": "value1-child"})
 
-	ctx2 := context.WithValue(ctx1, testContextKey("keyNotStored2"), "valueNotStored2")
-	ctx2 = common.SetBasics(ctx2, common.Basics{"key1": "value1-replaced"})
-	ctx2 = common.SetExtras(ctx2, common.Extras{"key2": "value2"})
+	grandchildCtx := context.WithValue(childCtx, testContextKey("keyNotStored2"), "valueNotStored2")
+	grandchildCtx = common.SetBasics(grandchildCtx, common.Basics{"key1": "value1-grandchild"})
+	grandchildCtx = common.SetExtras(grandchildCtx, common.Extras{"key3": "value3"})
 
-	childErr2 := New(ctx2, Op(grandchildOp), NotFound, grandchildErrMsg)
-	childErr1 := New(ctx1, Op(childOp), BadRequest, childErrMsg, childErr2)
-	gotErr := New(ctx0, Op(parentOp), parentErrMsg, childErr1)
+	grandChildErr := New(Op(grandchildOp), NotFound, grandchildErrMsg).
+		WithContext(grandchildCtx)
+
+	childErr := New(Op(childOp), BadRequest, childErrMsg, grandChildErr).
+		WithContext(childCtx)
+
+	err := New(Op(parentOp), parentErrMsg, childErr).
+		WithContext(ctx)
 
 	wantErr := &Error{
 		Op:  parentOp,
@@ -49,32 +56,37 @@ func TestNew_NestedContext_ParentContext(t *testing.T) {
 		},
 		ctx: map[string]any{
 			"basics": common.Basics{
-				"key1": "value1-replaced",
+				"key1": "value1-grandchild", // We should keep the latest value which is usually set by the lowest node.
+				"key2": "value2",
 			},
 			"extras": common.Extras{
-				"key2": "value2",
+				"key3": "value3",
 			},
 		},
 	}
 
-	assert.Equal(wantErr, gotErr)
+	assert.Equal(wantErr, err)
 }
 
 func TestNew_NestedContext_ChildsOwnContext(t *testing.T) {
 	assert := assert.New(t)
 
 	// Child setting their own `context.Background()`
-	ctx1 := context.WithValue(context.Background(), testContextKey("keyNotStored1"), "valueNotStored1")
-	ctx1 = common.SetBasics(ctx1, common.Basics{"key1": "value1"})
+	childCtx := context.WithValue(context.Background(), testContextKey("key-not-stored1"), "value-not-stored1")
+	childCtx = common.SetBasics(childCtx, common.Basics{"key1": "value1-child"})
 
 	// Child setting their own `context.Background()`
-	ctx2 := context.WithValue(context.Background(), testContextKey("keyNotStored2"), "valueNotStored2")
-	ctx2 = common.SetBasics(ctx2, common.Basics{"key1": "value1-replaced"})
-	ctx2 = common.SetExtras(ctx2, common.Extras{"key2": "value2"})
+	grandchildCtx := context.WithValue(context.Background(), testContextKey("key-not-stored2"), "value-not-stored2")
+	grandchildCtx = common.SetBasics(grandchildCtx, common.Basics{"key1": "value1-grandchild"})
+	grandchildCtx = common.SetExtras(grandchildCtx, common.Extras{"key2": "value2"})
 
-	childErr2 := New(ctx2, Op(grandchildOp), NotFound, grandchildErrMsg)
-	childErr1 := New(ctx1, Op(childOp), BadRequest, childErrMsg, childErr2)
-	gotErr := New(context.Background(), Op(parentOp), parentErrMsg, childErr1)
+	grandChildErr := New(Op(grandchildOp), NotFound, grandchildErrMsg).
+		WithContext(grandchildCtx)
+
+	childErr := New(Op(childOp), BadRequest, childErrMsg, grandChildErr).
+		WithContext(childCtx)
+
+	err := New(Op(parentOp), parentErrMsg, childErr)
 
 	wantErr := &Error{
 		Op:  parentOp,
@@ -91,7 +103,7 @@ func TestNew_NestedContext_ChildsOwnContext(t *testing.T) {
 		},
 		ctx: map[string]any{
 			"basics": common.Basics{
-				"key1": "value1-replaced",
+				"key1": "value1-grandchild", // We should keep the latest value which is usually set by the lowest node.
 			},
 			"extras": common.Extras{
 				"key2": "value2",
@@ -99,17 +111,18 @@ func TestNew_NestedContext_ChildsOwnContext(t *testing.T) {
 		},
 	}
 
-	assert.Equal(wantErr, gotErr)
+	assert.Equal(wantErr, err)
 }
 
 func TestNew_NestedContext_NilChildContext(t *testing.T) {
 	assert := assert.New(t)
 
-	ctx0 := context.Background()
-	ctx0 = common.SetBasics(ctx0, common.Basics{"key1": "value1"})
+	ctx := context.Background()
+	ctx = common.SetBasics(ctx, common.Basics{"key1": "value1"})
 
-	childErr1 := New(nil, Op(childOp), BadRequest, childErrMsg)
-	gotErr := New(ctx0, Op(parentOp), parentErrMsg, childErr1)
+	childErr := New(Op(childOp), BadRequest, childErrMsg)
+	err := New(Op(parentOp), parentErrMsg, childErr).
+		WithContext(ctx)
 
 	wantErr := &Error{
 		Op:  parentOp,
@@ -126,7 +139,7 @@ func TestNew_NestedContext_NilChildContext(t *testing.T) {
 		},
 	}
 
-	assert.Equal(wantErr, gotErr)
+	assert.Equal(wantErr, err)
 }
 
 func Test_basics(t *testing.T) {
@@ -137,17 +150,18 @@ func Test_basics(t *testing.T) {
 	childCtx = common.SetBasic(childCtx, "key2", "value2")
 	childCtx = common.SetExtra(childCtx, "key3", "value3")
 
-	childErr := New(childCtx, Op(childOp), childErrMsg)
-	err := New(ctx, Op(parentOp), "msg", childErr)
+	childErr := New(Op(childOp), childErrMsg).
+		WithContext(childCtx)
 
-	e, ok := err.(*Error)
-	assert.True(ok)
+	err := New(Op(parentOp), parentErrMsg, childErr).
+		WithContext(ctx)
 
+	assert.NotNil(err)
 	wantBasics := common.Basics{
 		"key1": "value1",
 		"key2": "value2",
 	}
-	assert.Equal(wantBasics, e.basics())
+	assert.Equal(wantBasics, err.basics())
 }
 
 func Test_extras(t *testing.T) {
@@ -158,15 +172,16 @@ func Test_extras(t *testing.T) {
 	childCtx = common.SetExtra(childCtx, "key2", "value2")
 	childCtx = common.SetExtra(childCtx, "key3", "value3")
 
-	childErr := New(childCtx, Op(childOp), childErrMsg)
-	err := New(ctx, Op(parentOp), "msg", childErr)
+	childErr := New(Op(childOp), childErrMsg).
+		WithContext(childCtx)
 
-	e, ok := err.(*Error)
-	assert.True(ok)
+	err := New(Op(parentOp), parentErrMsg, childErr).
+		WithContext(ctx)
 
+	assert.NotNil(err)
 	wantExtras := common.Extras{
 		"key2": "value2",
 		"key3": "value3",
 	}
-	assert.Equal(wantExtras, e.extras())
+	assert.Equal(wantExtras, err.extras())
 }


### PR DESCRIPTION
## Overview

This PR:

1. reverts the change that made `errors.New()` function take in a `context.Context`
2. adds a new `WithContext(context.Context)` method

This will allow us to use `WithContext` in places where we want to place contexts instead of polluting everywhere else with changes like:

```diff
- err := errors.New("err message")
+ err := errors.New(nil, "err message")
```

Now, we can work with the new `WithContext` method like:

```diff
- err := errors.New("err message")
+ err := errors.New("err message").WithContext(ctx)
```