### PR TITLE
Add round based on currency

### DIFF
--- a/currency/currency.go
+++ b/currency/currency.go
@@ -152,3 +152,19 @@ func GetCurrencyFactor(currency string) (factor float64) {
 func decimalPlaces(currencyCode string) uint8 {
 	return uint8(math.Log10(GetCurrencyFactor(currencyCode)))
 }
+
+// Round round half up the amount to the currency factor's decimal places
+func Round(currencyCode string, amount float64) (roundedAmount float64, err error) {
+	if !IsISO4217(currencyCode) {
+		return 0, fmt.Errorf("%s is not a valid ISO 4217 currency code", currencyCode)
+	}
+	switch {
+	case amount > 0:
+		factor := GetCurrencyFactor(currencyCode)
+		minorUnitAmount := math.Round(amount * factor)
+		roundedAmount = minorUnitAmount / factor
+	case amount < 0:
+		err = fmt.Errorf("invalid amount: %f", amount)
+	}
+	return
+}

--- a/logger/request_test.go
+++ b/logger/request_test.go
@@ -54,10 +54,9 @@ func Test_maskAuthorizationHeader(t *testing.T) {
 		},
 	}
 
-	assert := assert.New(t)
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
 			got := maskAuthorizationHeader(tc.value)
 
 			assert.Equal(tc.want, got)

--- a/secretsmanager/cmd/backup.go
+++ b/secretsmanager/cmd/backup.go
@@ -17,7 +17,7 @@ func BackupCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "backup",
 		Short: "Backup secret on AWS Secrets Manager",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			flag.Parse()
 
 			secretID, _ := cmd.Flags().GetString("secret-id")

--- a/secretsmanager/cmd/update.go
+++ b/secretsmanager/cmd/update.go
@@ -34,7 +34,7 @@ func UpdateCmd(c UpdateCmdConfig) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "update",
 		Short: "Update secret on AWS Secrets Manager",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			flag.Parse()
 
 			secretID, _ := cmd.Flags().GetString("secret-id")


### PR DESCRIPTION
- added `Round` in the currency package to round up a number to the currency factor's decimal places
- added tests

I think we can still get the desired result by combining `ToMinorUnit` and `FromMinorUnit`, but it will include a lot of duplicate checking, type-casting, and computations. This new method is much simpler and testable as well.

unrelated linter fix for `unused variable` (will not create a new version for these changes)
- logger
- secretsmanager/cmd



100% coverage unit test
<img width="1157" alt="image" src="https://github.com/wego/pkg/assets/131644118/280cc1ed-0603-4a2e-8130-ec7011f7d4c9">
