### PR TITLE
PAY-1289-fix-partner-logs-missing-athena-fields

### DIFF
--- a/logger/request.go
+++ b/logger/request.go
@@ -82,8 +82,18 @@ func (r *Request) GetBasic(key string) interface{} {
 func (r *Request) fields() []zapcore.Field {
 	var fields []zapcore.Field
 	for key, value := range r.Basics {
-		if v, err := json.Marshal(value); err == nil {
-			fields = append(fields, zap.String(key, string(v)))
+		if value == nil {
+			continue
+		}
+
+		v, err := json.Marshal(value)
+		if err != nil {
+			continue
+		}
+
+		val := string(v)
+		if val != `""` {
+			fields = append(fields, zap.String(key, val))
 		}
 	}
 	fields = append(fields, []zapcore.Field{

--- a/logger/request_test.go
+++ b/logger/request_test.go
@@ -2,8 +2,10 @@ package logger
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wego/pkg/errors"
 )
 
 func Test_maskAuthorizationHeader(t *testing.T) {
@@ -60,6 +62,93 @@ func Test_maskAuthorizationHeader(t *testing.T) {
 			got := maskAuthorizationHeader(tc.value)
 
 			assert.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestRequest_fields(t *testing.T) {
+	staticFieldsCount := 11
+	requestedAt := time.Now()
+	duration := 100 * time.Millisecond
+
+	tests := []struct {
+		name    string
+		request *Request
+		wantLen int // Expected number of fields in the output
+		wantErr bool
+	}{
+		{
+			name:    "Empty Request",
+			request: &Request{},
+			wantLen: staticFieldsCount, // Only the static fields are added
+		},
+		{
+			name: "Full Request",
+			request: &Request{
+				Basics: map[string]interface{}{
+					"nullField":   nil,
+					"paymentRef":  "abc123",
+					"emptyField1": "",
+					"nullField2":  nil,
+					"orderRef":    "zxc-456",
+					"emptyField2": "",
+				},
+				Type:            "GET",
+				Method:          "POST",
+				URL:             "http://example.com",
+				RequestHeaders:  Headers{},
+				RequestBody:     "request-body",
+				IP:              "127.0.0.1",
+				StatusCode:      200,
+				ResponseHeaders: Headers{},
+				ResponseBody:    "response-body",
+				RequestedAt:     requestedAt,
+				Duration:        duration,
+				Error:           errors.New("mock error"),
+			},
+			wantLen: 14, // All fields including Basics and Error
+		},
+		{
+			name: "Request with Unmarshallable Basics",
+			request: &Request{
+				Basics: map[string]interface{}{
+					"unmarshallable": make(chan int),
+				},
+			},
+			wantLen: staticFieldsCount, // Unmarshallable field is skipped
+			wantErr: true,              // Expecting error due to unmarshallable field
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			fields := tc.request.fields()
+
+			assert.Equal(tc.wantLen, len(fields))
+
+			if tc.wantLen > staticFieldsCount {
+				// assert basics
+				assert.Equal("paymentRef", fields[0].Key)
+				assert.Equal(`"abc123"`, fields[0].String)
+				assert.Equal("orderRef", fields[1].Key)
+				assert.Equal(`"zxc-456"`, fields[1].String)
+
+				// assert static fields
+				assert.Equal("GET", fields[2].String)
+				assert.Equal("POST", fields[3].String)
+				assert.Equal("http://example.com", fields[4].String)
+				assert.Equal(Headers{}, fields[5].Interface)
+				assert.Equal("request-body", fields[6].String)
+				assert.Equal("127.0.0.1", fields[7].String)
+				assert.Equal(int64(200), fields[8].Integer)
+				assert.Equal(Headers{}, fields[9].Interface)
+				assert.Equal("response-body", fields[10].String)
+				assert.Equal(requestedAt.Format(time.RFC3339), fields[11].String)
+				assert.Equal(duration.Milliseconds(), fields[12].Integer)
+				assert.Equal("mock error", fields[13].String)
+			}
 		})
 	}
 }

--- a/logger/request_test.go
+++ b/logger/request_test.go
@@ -130,10 +130,16 @@ func TestRequest_fields(t *testing.T) {
 
 			if tc.wantLen > staticFieldsCount {
 				// assert basics
-				assert.Equal("paymentRef", fields[0].Key)
-				assert.Equal(`"abc123"`, fields[0].String)
-				assert.Equal("orderRef", fields[1].Key)
-				assert.Equal(`"zxc-456"`, fields[1].String)
+				if fields[0].Key == "paymentRef" {
+					assert.Equal(`"abc123"`, fields[0].String)
+					assert.Equal("orderRef", fields[1].Key)
+					assert.Equal(`"zxc-456"`, fields[1].String)
+				} else {
+					assert.Equal("orderRef", fields[0].Key)
+					assert.Equal(`"zxc-456"`, fields[0].String)
+					assert.Equal(`"paymentRef"`, fields[1].Key)
+					assert.Equal(`"abc123"`, fields[1].String)
+				}
 
 				// assert static fields
 				assert.Equal("GET", fields[2].String)


### PR DESCRIPTION
- added checking of Basics value if not empty before adding to zapcode.Field
- added test

https://wegomushi.atlassian.net/browse/PAY-1289