### PR TITLE
add-where-clause-to-onconflict

### DIFF
--- a/database/clauses/clauses.go
+++ b/database/clauses/clauses.go
@@ -6,7 +6,7 @@ import (
 )
 
 // OnConflict adds an ON CONFLICT clause to the query
-func OnConflict(tx *gorm.DB, idx string) {
+func OnConflict(tx *gorm.DB, idx string, idxWhereCondition clause.Expr) {
 	index, ok := tx.Statement.Schema.ParseIndexes()[idx]
 	if !ok || index.Class != "UNIQUE" {
 		return
@@ -18,7 +18,8 @@ func OnConflict(tx *gorm.DB, idx string) {
 	}
 
 	tx.Statement.AddClause(clause.OnConflict{
-		Columns:   cols,
-		UpdateAll: true,
+		Columns:     cols,
+		UpdateAll:   true,
+		TargetWhere: clause.Where{Exprs: []clause.Expression{idxWhereCondition}},
 	})
 }

--- a/database/clauses/go.mod
+++ b/database/clauses/go.mod
@@ -1,6 +1,6 @@
 module github.com/wego/pkg/database/clauses
 
-go 1.19
+go 1.21
 
 require gorm.io/gorm v1.25.1
 


### PR DESCRIPTION
- added where condition to `clauses.onConflict()` to cater unique indexes with where clause
- update go version of clauses to 1.21