### PR TITLE
set-where-clause-in-onconflict

### DIFF
--- a/database/clauses/clauses.go
+++ b/database/clauses/clauses.go
@@ -23,7 +23,7 @@ func OnConflict(tx *gorm.DB, idx string, idxWhereCondition *clause.Expr) {
 	}
 
 	if idxWhereCondition != nil {
-		onConflictClause.TargetWhere = clause.Where{Exprs: []clause.Expression{idxWhereCondition}}
+		onConflictClause.TargetWhere = clause.Where{Exprs: []clause.Expression{*idxWhereCondition}}
 	}
 
 	tx.Statement.AddClause(onConflictClause)

--- a/database/clauses/clauses.go
+++ b/database/clauses/clauses.go
@@ -1,12 +1,13 @@
 package clauses
 
 import (
+	"github.com/wego/pkg/strings"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
 // OnConflict adds an ON CONFLICT clause to the query
-func OnConflict(tx *gorm.DB, idx string, idxWhereCondition *clause.Expr) {
+func OnConflict(tx *gorm.DB, idx string) {
 	index, ok := tx.Statement.Schema.ParseIndexes()[idx]
 	if !ok || index.Class != "UNIQUE" {
 		return
@@ -22,8 +23,10 @@ func OnConflict(tx *gorm.DB, idx string, idxWhereCondition *clause.Expr) {
 		UpdateAll: true,
 	}
 
-	if idxWhereCondition != nil {
-		onConflictClause.TargetWhere = clause.Where{Exprs: []clause.Expression{*idxWhereCondition}}
+	if strings.IsNotBlank(index.Where) {
+		onConflictClause.TargetWhere = clause.Where{Exprs: []clause.Expression{
+			clause.Expr{SQL: index.Where},
+		}}
 	}
 
 	tx.Statement.AddClause(onConflictClause)

--- a/database/clauses/clauses.go
+++ b/database/clauses/clauses.go
@@ -6,7 +6,7 @@ import (
 )
 
 // OnConflict adds an ON CONFLICT clause to the query
-func OnConflict(tx *gorm.DB, idx string, idxWhereCondition clause.Expr) {
+func OnConflict(tx *gorm.DB, idx string, idxWhereCondition *clause.Expr) {
 	index, ok := tx.Statement.Schema.ParseIndexes()[idx]
 	if !ok || index.Class != "UNIQUE" {
 		return
@@ -17,9 +17,14 @@ func OnConflict(tx *gorm.DB, idx string, idxWhereCondition clause.Expr) {
 		cols[i] = clause.Column{Name: col.DBName}
 	}
 
-	tx.Statement.AddClause(clause.OnConflict{
-		Columns:     cols,
-		UpdateAll:   true,
-		TargetWhere: clause.Where{Exprs: []clause.Expression{idxWhereCondition}},
-	})
+	onConflictClause := clause.OnConflict{
+		Columns:   cols,
+		UpdateAll: true,
+	}
+
+	if idxWhereCondition != nil {
+		onConflictClause.TargetWhere = clause.Where{Exprs: []clause.Expression{idxWhereCondition}}
+	}
+
+	tx.Statement.AddClause(onConflictClause)
 }

--- a/database/clauses/go.mod
+++ b/database/clauses/go.mod
@@ -7,4 +7,5 @@ require gorm.io/gorm v1.25.1
 require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/wego/pkg/strings v0.1.0 // indirect
 )

--- a/database/clauses/go.sum
+++ b/database/clauses/go.sum
@@ -2,5 +2,7 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/wego/pkg/strings v0.1.0 h1:MNIN5+ctJh7LVOvTxkMlTniaunS+eDtJtGYYtkgi8us=
+github.com/wego/pkg/strings v0.1.0/go.mod h1:cn+GuBzi3VTPS6zdsSiMiN6Wr3nVhd0cdmX1BgaMgvQ=
 gorm.io/gorm v1.25.1 h1:nsSALe5Pr+cM3V1qwwQ7rOkw+6UeLrX5O4v3llhHa64=
 gorm.io/gorm v1.25.1/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=


### PR DESCRIPTION
- removed `idxWhereCondition ` `Expr` param
- since gorm requires us to defined the index definition tag of the entity, we can get the where clause from the gorm index and use it directly
- added wego strings dependency