### PR TITLE
PAY-1443-update-date-format-of-logger-requestedAt

### DIFF
--- a/logger/request.go
+++ b/logger/request.go
@@ -106,7 +106,7 @@ func (r *Request) fields() []zapcore.Field {
 		zap.Int32("status_code", r.StatusCode),
 		zap.Array("response_headers", r.ResponseHeaders),
 		zap.String("response_body", r.ResponseBody),
-		zap.String("requested_at", r.RequestedAt.Format(time.RFC3339)),
+		zap.String("requested_at", r.RequestedAt.Format(time.RFC3339Nano)),
 		zap.Int64("duration_in_ms", r.Duration.Milliseconds()),
 	}...)
 

--- a/logger/request_test.go
+++ b/logger/request_test.go
@@ -151,7 +151,7 @@ func TestRequest_fields(t *testing.T) {
 				assert.Equal(int64(200), fields[8].Integer)
 				assert.Equal(Headers{}, fields[9].Interface)
 				assert.Equal("response-body", fields[10].String)
-				assert.Equal(requestedAt.Format(time.RFC3339), fields[11].String)
+				assert.Equal(requestedAt.Format(time.RFC3339Nano), fields[11].String)
 				assert.Equal(duration.Milliseconds(), fields[12].Integer)
 				assert.Equal("mock error", fields[13].String)
 			}


### PR DESCRIPTION
- updated `requested_at` format from RFC3339 to RFC3339Nano

| before | after |
| ---- | ---- |
| 2024-10-13T15:07:07Z | 2024-10-15T03:17:52.627462021Z |