### PR TITLE
add-marshal-unmarshal-text-param-for-common-date

### DIFF
--- a/common/context.go
+++ b/common/context.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+
 	"github.com/DataDog/datadog-go/statsd"
 )
 
@@ -33,7 +34,7 @@ func GetString(ctx context.Context, key ContextKey) (value string) {
 func GetBasic(ctx context.Context, key string) (value interface{}) {
 	if ctx != nil {
 		if basics, ok := ctx.Value(ctxBasics).(Basics); ok {
-			value, _ = basics[key]
+			value = basics[key]
 		}
 	}
 	return
@@ -90,7 +91,7 @@ func SetExtras(parent context.Context, extras Extras) context.Context {
 func GetExtra(ctx context.Context, key string) (value interface{}) {
 	if ctx != nil {
 		if extras, ok := ctx.Value(ctxExtras).(Extras); ok {
-			value, _ = extras[key]
+			value = extras[key]
 		}
 	}
 	return

--- a/common/date.go
+++ b/common/date.go
@@ -11,7 +11,7 @@ type Date time.Time
 
 const layout = "2006-01-02"
 
-// UnmarshalJSON Parses the json string into Date
+// UnmarshalJSON Parses the json string to the Date
 func (d *Date) UnmarshalJSON(b []byte) (err error) {
 	s := strings.Trim(string(b), `"`)
 	nt, err := time.Parse(layout, s)
@@ -24,7 +24,7 @@ func (d Date) MarshalJSON() ([]byte, error) {
 	return []byte(d.quote()), nil
 }
 
-// UnmarshalText Parses the text string into Date
+// UnmarshalText Parses the text string to the Date
 func (d *Date) UnmarshalText(text []byte) (err error) {
 	s := strings.Trim(string(text), `"`)
 	parsedTime, err := time.Parse(layout, s)
@@ -35,6 +35,14 @@ func (d *Date) UnmarshalText(text []byte) (err error) {
 // MarshalText marshall Date into Text
 func (d Date) MarshalText() ([]byte, error) {
 	return []byte(d.quote()), nil
+}
+
+// UnmarshalParam Parses the form's value to the Date
+func (d *Date) UnmarshalParam(param string) (err error) {
+	s := strings.Trim(param, `"`)
+	parsedTime, err := time.Parse(layout, s)
+	*d = Date(parsedTime)
+	return
 }
 
 // String returns the time in the custom format

--- a/common/date.go
+++ b/common/date.go
@@ -11,7 +11,7 @@ type Date time.Time
 
 const layout = "2006-01-02"
 
-// UnmarshalJSON Parses the json string in the Date
+// UnmarshalJSON Parses the json string into Date
 func (d *Date) UnmarshalJSON(b []byte) (err error) {
 	s := strings.Trim(string(b), `"`)
 	nt, err := time.Parse(layout, s)
@@ -21,6 +21,19 @@ func (d *Date) UnmarshalJSON(b []byte) (err error) {
 
 // MarshalJSON marshall Date into JSON
 func (d Date) MarshalJSON() ([]byte, error) {
+	return []byte(d.quote()), nil
+}
+
+// UnmarshalText Parses the text string into Date
+func (d *Date) UnmarshalText(text []byte) (err error) {
+	s := strings.Trim(string(text), `"`)
+	parsedTime, err := time.Parse(layout, s)
+	*d = Date(parsedTime)
+	return
+}
+
+// MarshalText marshall Date into Text
+func (d Date) MarshalText() ([]byte, error) {
 	return []byte(d.quote()), nil
 }
 

--- a/common/date_test.go
+++ b/common/date_test.go
@@ -1,0 +1,180 @@
+package common_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wego/pkg/common"
+)
+
+func TestDate_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected common.Date
+		hasError bool
+	}{
+		{
+			name:     "Invalid date format",
+			input:    []byte(`"2020-30-02"`),
+			expected: common.Date{},
+			hasError: true,
+		},
+		{
+			name:     "Empty date",
+			input:    []byte(`""`),
+			expected: common.Date{},
+			hasError: true,
+		},
+		{
+			name:     "Normal date without quotes",
+			input:    []byte(`1999-12-31`),
+			expected: common.Date(time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC)),
+			hasError: false,
+		},
+		{
+			name:     "Normal date with quotes",
+			input:    []byte(`"1999-12-31"`),
+			expected: common.Date(time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC)),
+			hasError: false,
+		},
+	}
+
+	assert := assert.New(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var result common.Date
+			err := result.UnmarshalJSON(tc.input)
+
+			if tc.hasError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+			assert.Equal(tc.expected, result)
+		})
+	}
+}
+
+func TestDate_MarshallJson(t *testing.T) {
+	assert := assert.New(t)
+
+	date := common.Date(time.Date(1999, 12, 31, 11, 11, 11, 0, time.Local))
+	result, err := date.MarshalJSON()
+	assert.NoError(err)
+	assert.Equal([]byte(`"1999-12-31"`), result)
+}
+
+func TestDate_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected common.Date
+		hasError bool
+	}{
+		{
+			name:     "Invalid date format",
+			input:    []byte(`"2020-30-02"`),
+			expected: common.Date{},
+			hasError: true,
+		},
+		{
+			name:     "Empty date",
+			input:    []byte(`""`),
+			expected: common.Date{},
+			hasError: true,
+		},
+		{
+			name:     "Normal date without quotes",
+			input:    []byte(`1999-12-31`),
+			expected: common.Date(time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC)),
+			hasError: false,
+		},
+		{
+			name:     "Normal date with quotes",
+			input:    []byte(`"1999-12-31"`),
+			expected: common.Date(time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC)),
+			hasError: false,
+		},
+	}
+
+	assert := assert.New(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var result common.Date
+			err := result.UnmarshalText(tc.input)
+
+			if tc.hasError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+			assert.Equal(tc.expected, result)
+		})
+	}
+}
+
+func TestDate_MarshallText(t *testing.T) {
+	assert := assert.New(t)
+
+	date := common.Date(time.Date(1999, 12, 31, 11, 11, 11, 0, time.Local))
+	result, err := date.MarshalText()
+	assert.NoError(err)
+	assert.Equal([]byte(`"1999-12-31"`), result)
+}
+
+func TestDate_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		date     common.Date
+		expected string
+	}{
+		{
+			name:     "single digit day",
+			date:     common.Date(time.Date(2023, 10, 5, 11, 11, 11, 0, time.Local)),
+			expected: "2023-10-05",
+		},
+		{
+			name:     "double digit month and day",
+			date:     common.Date(time.Date(1999, 12, 31, 11, 11, 11, 0, time.Local)),
+			expected: "1999-12-31",
+		},
+		{
+			name:     "single digit month and day",
+			date:     common.Date(time.Date(2000, 1, 1, 11, 11, 11, 0, time.Local)),
+			expected: "2000-01-01",
+		},
+	}
+
+	assert := assert.New(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.date.String()
+			assert.Equal(tc.expected, result)
+		})
+	}
+}
+
+func TestDate_Before(t *testing.T) {
+	assert := assert.New(t)
+
+	now := time.Now()
+	assert.True(common.Date(now).Before(common.Date(now.Add(time.Hour))))
+	assert.False(common.Date(now.Add(time.Hour)).Before(common.Date(now)))
+}
+
+func TestDate_IsZero(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(common.Date{}.IsZero())
+	assert.False(common.Date(time.Now()).IsZero())
+}
+
+func TestDate_Equal(t *testing.T) {
+	assert := assert.New(t)
+
+	now := time.Now()
+	assert.True(common.Date(now).Equal(now))
+	assert.False(common.Date(now).Equal(now.Add(time.Hour)))
+}

--- a/common/date_test.go
+++ b/common/date_test.go
@@ -66,6 +66,64 @@ func TestDate_MarshallJson(t *testing.T) {
 	assert.Equal([]byte(`"1999-12-31"`), result)
 }
 
+func TestDate_UnmarshalParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected common.Date
+		hasError bool
+	}{
+		{
+			name:     "Invalid date format",
+			input:    `"2020-30-02"`,
+			expected: common.Date{},
+			hasError: true,
+		},
+		{
+			name:     "Empty date",
+			input:    `""`,
+			expected: common.Date{},
+			hasError: true,
+		},
+		{
+			name:     "Normal date without quotes",
+			input:    `1999-12-31`,
+			expected: common.Date(time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC)),
+			hasError: false,
+		},
+		{
+			name:     "Normal date with quotes",
+			input:    `"1999-12-31"`,
+			expected: common.Date(time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC)),
+			hasError: false,
+		},
+	}
+
+	assert := assert.New(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var result common.Date
+			err := result.UnmarshalParam(tc.input)
+
+			if tc.hasError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+			assert.Equal(tc.expected, result)
+		})
+	}
+}
+
+func TestDate_MarshallText(t *testing.T) {
+	assert := assert.New(t)
+
+	date := common.Date(time.Date(1999, 12, 31, 11, 11, 11, 0, time.Local))
+	result, err := date.MarshalText()
+	assert.NoError(err)
+	assert.Equal([]byte(`"1999-12-31"`), result)
+}
+
 func TestDate_UnmarshalText(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -113,15 +171,6 @@ func TestDate_UnmarshalText(t *testing.T) {
 			assert.Equal(tc.expected, result)
 		})
 	}
-}
-
-func TestDate_MarshallText(t *testing.T) {
-	assert := assert.New(t)
-
-	date := common.Date(time.Date(1999, 12, 31, 11, 11, 11, 0, time.Local))
-	result, err := date.MarshalText()
-	assert.NoError(err)
-	assert.Equal([]byte(`"1999-12-31"`), result)
 }
 
 func TestDate_String(t *testing.T) {


### PR DESCRIPTION
- add marshal and unmarshal text
- add UnmarshalParam to be able to use common.Date in query param binding
https://github.com/gin-gonic/gin/pull/3933
- minor refactor in context.go
- added tests

We need to upgrade our gin version from `1.9.1` to `1.10.0`, but there are a lot of [changes](https://github.com/gin-gonic/gin/releases). We can defer this change for now.