### PR TITLE
Validate curve points in PublicKeyFromBytes [PAY-2108]

### DIFF
--- a/encryption/ecies/publickey.go
+++ b/encryption/ecies/publickey.go
@@ -36,11 +36,15 @@ func PublicKeyFromBytes(b []byte, curve elliptic.Curve) (*PublicKey, error) {
 		return nil, fmt.Errorf("invalid key length")
 	}
 
+	x := new(big.Int).SetBytes(b[1 : size+1])
+	y := new(big.Int).SetBytes(b[size+1:])
+	if !curve.IsOnCurve(x, y) {
+		return nil, fmt.Errorf("point is not on the curve")
+	}
+
 	return &PublicKey{
 		curve: curve,
-		Point: &Point{
-			X: new(big.Int).SetBytes(b[1 : size+1]),
-			Y: new(big.Int).SetBytes(b[size+1:])},
+		Point: &Point{X: x, Y: y},
 	}, nil
 }
 

--- a/encryption/ecies/publickey.go
+++ b/encryption/ecies/publickey.go
@@ -38,6 +38,11 @@ func PublicKeyFromBytes(b []byte, curve elliptic.Curve) (*PublicKey, error) {
 
 	x := new(big.Int).SetBytes(b[1 : size+1])
 	y := new(big.Int).SetBytes(b[size+1:])
+
+	// Reject points not on the curve to prevent crypto/elliptic.ScalarMult panics
+	// introduced in Go 1.24+. Without this check, corrupted or malicious payloads
+	// with valid-length but off-curve coordinates cause a panic in ECDH computation.
+	// See PAY-2108.
 	if !curve.IsOnCurve(x, y) {
 		return nil, fmt.Errorf("point is not on the curve")
 	}

--- a/encryption/ecies/publickey_test.go
+++ b/encryption/ecies/publickey_test.go
@@ -1,6 +1,10 @@
 package ecies_test
 
 import (
+	"crypto/elliptic"
+	"encoding/base64"
+	"encoding/hex"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,5 +63,45 @@ func Test_PublicKeyFromHex_Error(t *testing.T) {
 	pub, err = ecies.PublicKeyFromHex(hex, curve)
 	assert.Error(err)
 	assert.Contains(err.Error(), "invalid key length")
+	assert.Nil(pub)
+}
+
+// invalidP521Bytes returns uncompressed P521 public key bytes (0x04 || X || Y)
+// with X=1, Y=1 which is not on the P521 curve.
+func invalidP521Bytes() []byte {
+	size := (elliptic.P521().Params().BitSize + 7) / 8 // 66
+	b := make([]byte, 1+2*size)
+	b[0] = 0x04
+	big.NewInt(1).FillBytes(b[1 : size+1])
+	big.NewInt(1).FillBytes(b[size+1:])
+	return b
+}
+
+func Test_PublicKeyFromBytes_InvalidCurvePoint(t *testing.T) {
+	assert := assert.New(t)
+
+	pub, err := ecies.PublicKeyFromBytes(invalidP521Bytes(), elliptic.P521())
+	assert.Error(err)
+	assert.Contains(err.Error(), "point is not on the curve")
+	assert.Nil(pub)
+}
+
+func Test_PublicKeyFromBase64_InvalidCurvePoint(t *testing.T) {
+	assert := assert.New(t)
+
+	b64 := base64.StdEncoding.EncodeToString(invalidP521Bytes())
+	pub, err := ecies.PublicKeyFromBase64(b64, elliptic.P521())
+	assert.Error(err)
+	assert.Contains(err.Error(), "point is not on the curve")
+	assert.Nil(pub)
+}
+
+func Test_PublicKeyFromHex_InvalidCurvePoint(t *testing.T) {
+	assert := assert.New(t)
+
+	h := hex.EncodeToString(invalidP521Bytes())
+	pub, err := ecies.PublicKeyFromHex(h, elliptic.P521())
+	assert.Error(err)
+	assert.Contains(err.Error(), "point is not on the curve")
 	assert.Nil(pub)
 }

--- a/encryption/ecies/publickey_test.go
+++ b/encryption/ecies/publickey_test.go
@@ -66,17 +66,22 @@ func Test_PublicKeyFromHex_Error(t *testing.T) {
 	assert.Nil(pub)
 }
 
-// invalidP521Bytes returns uncompressed P521 public key bytes (0x04 || X || Y)
-// with X=1, Y=1 which is not on the P521 curve.
+// invalidP521Bytes builds a well-formed uncompressed public key (0x04 || X || Y)
+// whose coordinates (1, 1) are NOT on the P521 curve.
+// This simulates corrupted or malicious encrypted payloads where the embedded
+// ephemeral public key has valid length but invalid curve coordinates.
+// Go 1.24+ panics in crypto/elliptic.ScalarMult for such points (PAY-2108).
 func invalidP521Bytes() []byte {
-	size := (elliptic.P521().Params().BitSize + 7) / 8 // 66
+	size := (elliptic.P521().Params().BitSize + 7) / 8 // 66 bytes
 	b := make([]byte, 1+2*size)
-	b[0] = 0x04
+	b[0] = 0x04 // uncompressed point prefix
 	big.NewInt(1).FillBytes(b[1 : size+1])
 	big.NewInt(1).FillBytes(b[size+1:])
 	return b
 }
 
+// Test_PublicKeyFromBytes_InvalidCurvePoint verifies that off-curve points are
+// rejected at parse time rather than causing a panic in downstream ScalarMult.
 func Test_PublicKeyFromBytes_InvalidCurvePoint(t *testing.T) {
 	assert := assert.New(t)
 
@@ -86,6 +91,8 @@ func Test_PublicKeyFromBytes_InvalidCurvePoint(t *testing.T) {
 	assert.Nil(pub)
 }
 
+// Test_PublicKeyFromBase64_InvalidCurvePoint ensures the validation propagates
+// through the base64 parsing path (PublicKeyFromBase64 -> PublicKeyFromBytes).
 func Test_PublicKeyFromBase64_InvalidCurvePoint(t *testing.T) {
 	assert := assert.New(t)
 
@@ -96,6 +103,8 @@ func Test_PublicKeyFromBase64_InvalidCurvePoint(t *testing.T) {
 	assert.Nil(pub)
 }
 
+// Test_PublicKeyFromHex_InvalidCurvePoint ensures the validation propagates
+// through the hex parsing path (PublicKeyFromHex -> PublicKeyFromBytes).
 func Test_PublicKeyFromHex_InvalidCurvePoint(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
## Summary

- Add `IsOnCurve` validation to `PublicKeyFromBytes` to reject invalid elliptic curve points at parse time
- Prevents `crypto/elliptic.ScalarMult` panics introduced in Go 1.24+ when input points are not on the curve
- PEM-based functions (`PublicKeyFromPEMBytes/File/String`) already validate via `x509.ParsePKIXPublicKey` — no changes needed

## Context

Production panic (PD Q2Z7JW0X8JIFID) caused by `crypto/elliptic.Curve.ScalarMult` panicking on invalid curve points after Go version bump. `PublicKeyFromBytes` parsed X,Y coordinates without validating they are on the curve. When corrupted/malformed encrypted data is received, the embedded ephemeral public key may not be on P521, causing a panic in ECDH shared secret computation.

## Changes

- `encryption/ecies/publickey.go`: Add `curve.IsOnCurve(x, y)` check in `PublicKeyFromBytes` before constructing the `PublicKey`
- `encryption/ecies/publickey_test.go`: Add tests for `PublicKeyFromBytes`, `PublicKeyFromBase64`, and `PublicKeyFromHex` with off-curve points (X=1, Y=1 on P521)

## Test plan

- [x] `Test_PublicKeyFromBytes_InvalidCurvePoint` — returns error, not panic
- [x] `Test_PublicKeyFromBase64_InvalidCurvePoint` — returns error, not panic
- [x] `Test_PublicKeyFromHex_InvalidCurvePoint` — returns error, not panic
- [x] All existing tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)