### PR TITLE
Remove env variable from promo code events log filename

### DIFF
--- a/logger/const.go
+++ b/logger/const.go
@@ -14,7 +14,7 @@ const (
 	ultronExFileName        = "ultronex.{{env}}.log"
 	partnerRequestsFileName = "partner_requests.{{env}}.log"
 	requestsFileName        = "requests.{{env}}.log"
-	promoCodeEventsFileName = "promocode_events.{{env}}.log"
+	promoCodeEventsFileName = "promocode_events.log"
 	defaultReplacement      = "[Filtered by Wego]"
 	defaultMaskChar         = "*"
 	arrayKey                = "[]"


### PR DESCRIPTION
## Summary
- Removed `{{env}}` from `promoCodeEventsFileName` constant, changing the log filename from `promocode_events.{{env}}.log` to `promocode_events.log`
- The `strings.Replace` call in `initLogger` becomes a no-op for this filename, so no other code changes are needed

## Test plan
- [ ] Verify the promo code event logger initializes correctly and writes to `promocode_events.log`
- [ ] Confirm other loggers (ultronex, partner_requests, requests) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)