### PR TITLE
auto_version: skip non-publishable go.mod modules

### DIFF
--- a/auto_version
+++ b/auto_version
@@ -45,8 +45,21 @@ for remote in $(git remote); do
   git pull "$remote" "$current_branch"
 done
 
+module_root="github.com/wego/pkg"
+
 for dir in $(find . -name 'go.mod' -exec dirname {} \; | sort -u); do
   pkg=$(echo "$dir" | sed 's/\.\///')
+
+  # Only tag modules whose go.mod declares the canonical repo path.
+  # Auxiliary go.mod files (e.g. linter testdata fixtures, example modules)
+  # use unrelated module paths and must not be released.
+  declared_module=$(awk '/^module[[:space:]]/ { print $2; exit }' "$dir/go.mod")
+  expected_module="$module_root/$pkg"
+  if [[ "$declared_module" != "$expected_module" ]]; then
+    echo "skipping $pkg (module path \"$declared_module\" is not \"$expected_module\")"
+    continue
+  fi
+
   latest_version=$(git tag --sort=-v:refname -l "$pkg/v*" | head -1 | sed 's/.*\///')
 
   current_version=$latest_version


### PR DESCRIPTION
## Summary

- `auto_version` now reads the `module …` line from each `go.mod` and only tags directories whose declared path equals `github.com/wego/pkg/<relative-dir>`. Anything else is skipped with a reason.
- Fixes the recent erroneous tagging of `linters/isolint/testdata/v0.1.0`, `linters/isolint/testdata/v0.1.1`, and `linters/stringlint/testdata/v0.1.0`. Those directories are standalone Go modules only because `golang.org/x/tools/go/analysis/analysistest` requires fixtures to be a self-contained module, and they declare `module example` — they are not meant for consumption.
- Cleanup of the already-pushed bad tags is **not** part of this PR. Doing it separately so the destructive `git push :refs/tags/...` is reviewed on its own.

## Why module-path matching (and not the alternatives)

| Option | How it would work | Why rejected |
|---|---|---|
| Path filter `*/testdata/*` | `find … -not -path '*/testdata/*'` | Only covers the testdata convention. Misses any future auxiliary `go.mod` — `examples/`, `benchmarks/`, `cmd/playground/`, etc. Hardcodes one naming convention into the release tooling. |
| Marker file (`.no-release` / `.tagignore`) | Opt-out per directory | New convention to teach. Easy to forget when adding another linter; the failure mode is silent (a stray release tag). |
| Allow-list in script | Hardcode the publishable dirs | Every new package edits the script. Forgetting it means the package never gets tagged — silent failure in the other direction. |
| **Module-path check (chosen)** | Require `go.mod`'s `module …` line to equal `github.com/wego/pkg/<dir>`; skip with a logged reason otherwise | See below. |

### Why this is cleaner and scales

- **It tests the actual property we care about.** The release tooling's job is to publish wego/pkg modules. The truthful question is "does this `go.mod` declare itself as part of `github.com/wego/pkg`?" Module path matching answers that directly; every other option is a proxy.
- **No new convention.** It piggybacks on the `module` directive that `go.mod` files already have. Nothing new for contributors to remember.
- **Auto-handles every current and future case.** Linter testdata today, more linter fixtures tomorrow, example modules, benchmark harnesses — all handled without script changes, because none of them will declare a `github.com/wego/pkg/...` module path.
- **Self-documenting failure mode.** When something is skipped, the script logs `skipping <pkg> (module path "X" is not "Y")`. If a real package is misconfigured, the mismatch is loud and immediately diagnosable.
- **Works at any nesting depth.** The check concatenates `module_root + relative dir`, so `iso/site`, `http/middleware`, `linters/isolint`, and any future `a/b/c` resolve identically — no special casing.

### Verification

Dry-run against every `go.mod` in the repo classified all 33 publishable modules as `TAG` and both linter `testdata` fixtures as `SKIP` with the expected reason.

- [x] Separately (not in this PR) clean up the existing bad remote tags: `linters/isolint/testdata/v0.1.0`, `linters/isolint/testdata/v0.1.1`, `linters/stringlint/testdata/v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)