### PR TITLE
chore(ci): bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,13 +12,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-        # actions/checkout@v4.2.2
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Get changed files
         id: changed-files
-        # tj-actions/changed-files@v45.0.9
-        uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8
+        # tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
 
       - name: Get all changed packages
         id: updated_pkgs
@@ -62,8 +62,8 @@ jobs:
           echo "has_changed_packages=$has_changed_packages" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        # actions/setup-go@v5.4.0
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+        # actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         if: ${{ steps.updated_pkgs.outputs.has_changed_packages == 'true' }}
         with:
           go-version: ^1.20


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 in Actions runners. Node 20 will be **forced off** the runner on **2026-06-02** (default switches to Node 24) and **removed** on **2026-09-16**. See the [deprecation changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

This PR bumps every pinned action in `check.yml` whose current SHA still runs on Node 20 to the latest stable release that declares `using: node24`. The "comment-above-`uses:`" convention used in this file is preserved.

Tracking ticket: [PAY-2146](https://wegomushi.atlassian.net/browse/PAY-2146)
Reference thread: [#payments-platform discussion](https://wego.slack.com/archives/CDP0PB9HV/p1779330531336369)
Sibling PRs: [wego/olympias#3496](https://github.com/wego/olympias/pull/3496), [wego/payments#1988](https://github.com/wego/payments/pull/1988), [wego/payments-react-component#360](https://github.com/wego/payments-react-component/pull/360)

### Version changes

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4.2.2 | **v6.0.2** |
| `actions/setup-go` | v5.4.0 | **v6.4.0** |
| `tj-actions/changed-files` | v45.0.9 | **v47.0.6** |

`tj-actions/changed-files@v45.0.9` is also Node 20 per its `action.yml`, even though it was not named in GitHub's deprecation annotation. Bumping it here completes the Node 20 sweep for this workflow.

## Test plan

- [ ] `Run Style Check And Unit Test` (check.yml) passes on this PR — exercises `checkout`, `changed-files`, `setup-go`
- [ ] Confirm the _"Node.js 20 actions are deprecated"_ annotation no longer appears on the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PAY-2146]: https://wegomushi.atlassian.net/browse/PAY-2146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ