### PR TITLE
Add initial Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directories:
+      - "/audit"
+      - "/collection"
+      - "/common"
+      - "/currency"
+      - "/database/clauses"
+      - "/database/postgres"
+      - "/datetime"
+      - "/encoding"
+      - "/encryption"
+      - "/env"
+      - "/errors"
+      - "/host"
+      - "/http"
+      - "/http/auth"
+      - "/http/binding"
+      - "/http/header"
+      - "/http/jwt"
+      - "/http/middleware"
+      - "/http/wegin"
+      - "/integration-test"
+      - "/iso"
+      - "/iso/country"
+      - "/iso/site"
+      - "/linters/isolint"
+      - "/linters/stringlint"
+      - "/localization"
+      - "/logger"
+      - "/mocktest"
+      - "/pointer"
+      - "/rand"
+      - "/retry"
+      - "/secretsmanager"
+      - "/snowflake"
+      - "/strings"
+      - "/to"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+        group-by: "dependency-name"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds the repository's first Dependabot configuration for the Go modules in this multi-module repo and for the existing GitHub Actions workflow. This enables routine dependency update PRs without maintaining each module and workflow dependency by hand.

## Approach

- **Multi-module coverage:** uses one `gomod` update entry with `directories` for each real module root in the repo.
- **PR volume control:** groups Go updates by dependency name so the same dependency can be updated across modules in fewer PRs.
- **Fixture exclusion by omission:** leaves the `testdata` sample modules out so Dependabot does not open noise-only PRs for test fixtures.
- **Workflow maintenance:** adds a `github-actions` update entry for `/.github/workflows` using `directory: "/"`, which matches GitHub's documented behavior.
- **Minimal first config:** keeps the schedule weekly and avoids extra labels, reviewers, or registry settings until the repo has a baseline update flow.