### PR TITLE
[NO-JIRA] Restrict Dependabot to minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,11 @@ updates:
       - "/to"
     schedule:
       interval: "weekly"
+    # Major-version bumps frequently introduce breaking changes. Only auto-propose
+    # minor/patch updates; majors must be bumped deliberately with testing.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       go-dependencies:
         patterns:
@@ -49,3 +54,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
### Context

Restrict Dependabot so it stops automatically proposing major-version dependency bumps.

Major upgrades can introduce breaking behavior and should be reviewed intentionally instead of arriving as routine automated update PRs. This keeps minor and patch updates flowing while reducing noise and avoiding accidental major upgrades.

### Approach

Add a Dependabot `ignore` rule for `version-update:semver-major` with `dependency-name: "*"` to each existing ecosystem in `.github/dependabot.yml`:

- `gomod`
- `github-actions`

Minor and patch updates continue to be proposed weekly. Major updates now require a deliberate manual bump and testing before merging.

**Trade-off:** major upgrades will no longer appear as automatic Dependabot PRs. That is intentional because major bumps can contain breaking behavior and should be reviewed deliberately.

### Testing

CI-config-only change. No runtime behavior affected.

Local checks run:

- Structure check confirmed both Dependabot update entries include `version-update:semver-major` ignore rules.
- Confirmed existing Go dependency grouping remains in place.
- `git diff --check`
